### PR TITLE
RTPEngine Support for PBX behind dSIPRouter

### DIFF
--- a/kamailio/kamailio51_dsiprouter.tpl
+++ b/kamailio/kamailio51_dsiprouter.tpl
@@ -8,6 +8,8 @@
 #!define WITH_DROUTE
 ##!define WITH_DEBUG
 #!define WITH_NAT
+#!define WITH_PROXY_ALL_RTP
+#!define WITH_MULTI_HOMED
 #!define WITH_DISPATCHER
 ##!define WITH_SERVERNAT
 #!define WITH_MULTIDOMAIN


### PR DESCRIPTION
This takes into case more use cases as to how to route a call.  We are using this in production.  The only gotcha is if there is an external device added as a PBX that has the same IP as one of the extensions.