### PR TITLE
dsiprouter installation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 
 [//]: # (END_SECTION HEADER)
 [//]: # (START_SECTION COMMITS
-11626d32e8bff0485a74bd66a28f6a273ac641d2
+4341b057a1d72f7675e9e7958126989ce8148f72
+d39844eda0194d17dc47d205c5bc80ac1b4bb296
+a6c9c5a3fd93382c758002354e5e362516e70be7
+b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a
 348d856841f14014714bc55206cdbbfb4c849445
 e17b362a94175aaab6ffc9e711e95fa80df08acc
 b04ed0097dd4ba5867062c16ec2d654e72ac6d6e
@@ -1761,10 +1764,58 @@ a72121b9551921aa3dced32d943c6034ba318f82
 ce6c5aac0db5476dc496c34388e4f9ce2c4b86e5
 b46b1e64f06f448bde78b98e3ae8228ce5f96067
 END_SECTION COMMITS)
-[//]: # (START_SECTION 11626d32e8bff0485a74bd66a28f6a273ac641d2)
+[//]: # (START_SECTION 4341b057a1d72f7675e9e7958126989ce8148f72)
+### Add Missing Dependencies
+
+> Commit: [4341b057a1d72f7675e9e7958126989ce8148f72](https://github.com/dOpensource/dsiprouter/commit/4341b057a1d72f7675e9e7958126989ce8148f72)  
+> Date: Wed, 18 Nov 2020 17:29:02 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- add `sphinx-rtd-theme` and `uwsgi` dependency
+
+
+---
+
+[//]: # (END_SECTION 4341b057a1d72f7675e9e7958126989ce8148f72)
+[//]: # (START_SECTION d39844eda0194d17dc47d205c5bc80ac1b4bb296)
+### Fix RPM Search For CentOS Kernel Headers
+
+> Commit: [d39844eda0194d17dc47d205c5bc80ac1b4bb296](https://github.com/dOpensource/dsiprouter/commit/d39844eda0194d17dc47d205c5bc80ac1b4bb296)  
+> Date: Wed, 18 Nov 2020 16:49:11 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- add searching centos archives to `rpmSearch()`
+- add dnf support to `setVerbosityLevel()`
+
+
+---
+
+[//]: # (END_SECTION d39844eda0194d17dc47d205c5bc80ac1b4bb296)
+[//]: # (START_SECTION a6c9c5a3fd93382c758002354e5e362516e70be7)
+### Missing uwsgi and sphinx_rtd_theme python packages
+
+> Commit: [a6c9c5a3fd93382c758002354e5e362516e70be7](https://github.com/dOpensource/dsiprouter/commit/a6c9c5a3fd93382c758002354e5e362516e70be7)  
+> Date: Wed, 18 Nov 2020 09:58:56 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION a6c9c5a3fd93382c758002354e5e362516e70be7)
+[//]: # (START_SECTION b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a)
 ### dsiprouter installation fixes
 
-> Commit: [11626d32e8bff0485a74bd66a28f6a273ac641d2](https://github.com/dOpensource/dsiprouter/commit/11626d32e8bff0485a74bd66a28f6a273ac641d2)  
+> Commit: [b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a](https://github.com/dOpensource/dsiprouter/commit/b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a)  
 > Date: Tue, 17 Nov 2020 19:40:41 -0500  
 > Author: Tyler Moore (tmoore@goflyball.com)  
 > Committer: Tyler Moore (tmoore@goflyball.com)  
@@ -1791,7 +1842,7 @@ END_SECTION COMMITS)
 
 ---
 
-[//]: # (END_SECTION 11626d32e8bff0485a74bd66a28f6a273ac641d2)
+[//]: # (END_SECTION b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a)
 [//]: # (START_SECTION 348d856841f14014714bc55206cdbbfb4c849445)
 ### Fixes issue #291 and removes the default Nginx server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 [//]: # (END_SECTION HEADER)
 [//]: # (START_SECTION COMMITS
-4341b057a1d72f7675e9e7958126989ce8148f72
+59f1980c969e292a6f5d6a679d89e6fea2b5d1d5
+442594103964d1441361071ae1f367dce714bda9
 d39844eda0194d17dc47d205c5bc80ac1b4bb296
 a6c9c5a3fd93382c758002354e5e362516e70be7
 b883b914b2ca6c0e6d9908c4611e9c4251c2eb0a
@@ -1764,10 +1765,27 @@ a72121b9551921aa3dced32d943c6034ba318f82
 ce6c5aac0db5476dc496c34388e4f9ce2c4b86e5
 b46b1e64f06f448bde78b98e3ae8228ce5f96067
 END_SECTION COMMITS)
-[//]: # (START_SECTION 4341b057a1d72f7675e9e7958126989ce8148f72)
+[//]: # (START_SECTION 59f1980c969e292a6f5d6a679d89e6fea2b5d1d5)
+### Kamailio Module Load Ordering
+
+> Commit: [59f1980c969e292a6f5d6a679d89e6fea2b5d1d5](https://github.com/dOpensource/dsiprouter/commit/59f1980c969e292a6f5d6a679d89e6fea2b5d1d5)  
+> Date: Thu, 19 Nov 2020 11:21:50 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- fix load order for tls module
+- make sipdump conditionally load
+
+
+---
+
+[//]: # (END_SECTION 59f1980c969e292a6f5d6a679d89e6fea2b5d1d5)
+[//]: # (START_SECTION 442594103964d1441361071ae1f367dce714bda9)
 ### Add Missing Dependencies
 
-> Commit: [4341b057a1d72f7675e9e7958126989ce8148f72](https://github.com/dOpensource/dsiprouter/commit/4341b057a1d72f7675e9e7958126989ce8148f72)  
+> Commit: [442594103964d1441361071ae1f367dce714bda9](https://github.com/dOpensource/dsiprouter/commit/442594103964d1441361071ae1f367dce714bda9)  
 > Date: Wed, 18 Nov 2020 17:29:02 -0500  
 > Author: Tyler Moore (tmoore@goflyball.com)  
 > Committer: Tyler Moore (tmoore@goflyball.com)  
@@ -1779,7 +1797,7 @@ END_SECTION COMMITS)
 
 ---
 
-[//]: # (END_SECTION 4341b057a1d72f7675e9e7958126989ce8148f72)
+[//]: # (END_SECTION 442594103964d1441361071ae1f367dce714bda9)
 [//]: # (START_SECTION d39844eda0194d17dc47d205c5bc80ac1b4bb296)
 ### Fix RPM Search For CentOS Kernel Headers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,90 @@
 
 [//]: # (END_SECTION HEADER)
 [//]: # (START_SECTION COMMITS
-9bb6aba192ee95656f1d8cdae7c25b4b120c5c98
+11626d32e8bff0485a74bd66a28f6a273ac641d2
+348d856841f14014714bc55206cdbbfb4c849445
+e17b362a94175aaab6ffc9e711e95fa80df08acc
+b04ed0097dd4ba5867062c16ec2d654e72ac6d6e
+315cbdcde908c5e94fc7f283c2b9d0c76e63f4a6
+7f50034e56da5e6562eb3e03c813263a5c13fbb7
+52f64d507d7c5d867f3d8fbeb97aa52ad664ec36
+302a6275995e2398f18aa59ad871554456d4b68c
+979e7f28b2c2efbf113f898b689d6603bfd274e0
+7507cd91dffe48de1b52cd1060610332753dc890
+bad92e9378ef8164cd37f1c190f92e08ec4c5836
+e8480a8c7036b9965c4a7424fc438aa35e4d423b
+a2e9980ec557656d248823fc4366c7fa0f8edb24
+7b65855389c4be45c90bfb866eddc9451a8e1d9b
+16d2a8ea03bd62fbce4078450c714bab9625175d
+3fd6ffb00ebd98f4e93fe0e8db7a8c4121a6c670
+46667fae98f6c8b5ac627d4e0ab717413c9abb08
+31515bd149e609f6f676bb357d461d6e83a01608
+373b3b573a04bc6dfa83cab99bd9d881e799f741
+a4dff281c4621b70e411a6013293396a1b673c70
+aeb39781690a8641f1164d35fe1651f1fbfe355c
+07639d4e4af2b8232ad4835ca890f2c7e1ad7414
+9c97ea3d520064dde2bd147946e9181b3145dcc2
+dd45f9e65664bc3f4bf324e6bfbd5053f4d72e99
+5b6ff83b93434abffcc48d57b1b716d5194cb2a2
+bf8e7fc878dd464ca797d2eea74dad58332261ca
+3f3bb7416475875a443b77aa98f7f4886458c207
+73ed951374c89b5aacc089e88710118f4fdfc203
+e2c2b6d70dcad60da704a37e9800948dbbe469e2
+9cf083098084c9e450154138455c57cc2843952f
+2687815c353e29a9251ff41bdf334757d5376daf
+d72d5a8a07999ad84d0a1197db00e979b588f054
+22cab0ab976068d4b49ecd7d4fa02e65bea4849a
+10c95ab999173de41a257a626d3cd89017b52b1f
+a1d693a7da90ba8eaaca8134f36260485f2f051c
+9243cade3cdb3c1cbbe77a3ca0a46ef8cc593d47
+dfcc241369d1b0f5abbbc163493bfbd3273bbc66
+6258abfd7c1817492550798d663e3e5a5c3a54c8
+247eb3fbb0690de397e3283df37eeee8dd53a6ea
+2b6ee47fc7611438ab7f2b0584cce3cf086ca6f4
+20c240e9c512c3d4966f0f7ca4142b80e8de896f
+9c57c6f953bed6e9348cd47ab06a132357ddf573
+db071da5fc4d62ffcb9e97ab8b5ed4a040c01de7
+c43e91b217077be43e04f48a2d014d096f274d59
+19c08a7c0a935506b65ae130bb5c1edb214cfbbf
+4c4110991857ec7ecbf5f1ce0280d3057b4ed9c7
+f595b16e67adcf5278e9bdcec065422cbe5c9b4b
+0f60305db7c4f3476af529ea7b778540e06a9958
+51efbde55b88dcd80688a6055608daa5fdb30a27
+e7e33f0ca3224bab3d75b40cdce93d3da36ccac6
+ed99fde349f38f1f1f5250ff4d9a02faecab9c3b
+b3f1701f70ea9a610e81a4bc08fa5e1ff3ac9a93
+220ec7f1827267091059abd467b88137e717ad94
 8976863ab2f8aee31a6222a0010e62d9b08a3be2
+2ebaca3cb6894916c37e7746e7f9b4c95473cbe0
 e3673ab836946e34bc759df32499a89bad460878
+aa88b8fc61ed0bac537901196b0a7b7fedc79ad4
+2c71440a60bee65291c6a88981857eb86279d958
+3525c446bb0056b05fe6745085ead8ba106403af
 02e128e74c941b83c3f8c1aea14c1387070c1393
+0b27f18583f624ac932f8d5cbabbd3b5407efd9f
+595544e72ea35d3e85034389459821b27716520a
+8697661b71b53e5dbf4e7e3755f3d6daea35248a
+2d69d1b3639238a9082d9dd1befe7b3b97fa8ad5
+fc41bcee84c9a43fc507116dd63d8b62dae7fdb2
+ab07be7a8d96b82155c8447d5e73bb7df8c9e6a3
+333d72ebbc833e2b2424cc63a0d19b23be9cc3c7
+0d97d8d35d0cb44c8ff2444964967acfbab8aaf3
+b6c1ba5ef380ab555007b98c54c5af03309c1042
+b89473a34ba4911150e72d636e7660763c6eb62d
+d9039e6c980daefce4e5e3e1acd81fc74864283c
+963a62c8dd0f0dea807bd2ecd041cab385e54daa
+fd2a050cb03bc8a496075f26ae7a8659739b4647
+69e29d707000c0414c64ee0b96530628364f0cc8
+dc31e424924c5e02936096bb158b6ac210979f68
+f73c6e8e4228f1009aa4820521ca638945e9bd20
+62485dd6238c815d2714729fac136dc37a7770b9
+b5d6c624ae39a2fe49d4107dd05af163936b4d35
+61ed44cd0573769b198807e232ebc005561d62a9
+2227edd47210f18a730d6a9abefa8256e09b996c
+79c5b318678348c4e3b3fa7b19f0f784b334f0e1
+3f31a4e61a2aa5e1cca17471bff1073f5652a649
+d4e7eaa96c7270a12b833c6d7430db5f1cd69405
+0aba1d2e1c1885f67df744297f296f8fa1d41202
 ebea34b830e20160c547ee399b0a89a42528354d
 97e1f9bdee0f277a10348208ced3c5ecc52fe030
 5292d8fdc00d79026d1ce6e3a08245308f8d60d5
@@ -1681,10 +1761,754 @@ a72121b9551921aa3dced32d943c6034ba318f82
 ce6c5aac0db5476dc496c34388e4f9ce2c4b86e5
 b46b1e64f06f448bde78b98e3ae8228ce5f96067
 END_SECTION COMMITS)
-[//]: # (START_SECTION 9bb6aba192ee95656f1d8cdae7c25b4b120c5c98)
+[//]: # (START_SECTION 11626d32e8bff0485a74bd66a28f6a273ac641d2)
+### dsiprouter installation fixes
+
+> Commit: [11626d32e8bff0485a74bd66a28f6a273ac641d2](https://github.com/dOpensource/dsiprouter/commit/11626d32e8bff0485a74bd66a28f6a273ac641d2)  
+> Date: Tue, 17 Nov 2020 19:40:41 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- fix psycopg2 dependency issue on centos
+- fix flask dependency issue on centos
+- fixup printing commands in sub-processes
+- fix kernel header lookups for rtpengine install
+- fixup centos rtpengine install code
+- change rtpengine to use kernel packet forwarding by default
+- improve efficiency by exporting sub-process required funcs
+- update rtpengine version to latest release
+- add nginx changes to centos8
+- update centos to use kamailio 5.3
+- fixed grep file checks outputting text during install
+- add some utility functions to `dsip_lib.sh`
+- revert centos8 to using mariadb instead of mysql
+- fix dependency conflicts between mysql-common and mariadb-common
+- fix centos8 python dependencies
+- various fixes for centos8 service install scripts
+
+
+---
+
+[//]: # (END_SECTION 11626d32e8bff0485a74bd66a28f6a273ac641d2)
+[//]: # (START_SECTION 348d856841f14014714bc55206cdbbfb4c849445)
+### Fixes issue #291 and removes the default Nginx server
+
+> Commit: [348d856841f14014714bc55206cdbbfb4c849445](https://github.com/dOpensource/dsiprouter/commit/348d856841f14014714bc55206cdbbfb4c849445)  
+> Date: Tue, 17 Nov 2020 00:56:39 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 348d856841f14014714bc55206cdbbfb4c849445)
+[//]: # (START_SECTION e17b362a94175aaab6ffc9e711e95fa80df08acc)
+### Fixed Debian 9 dSIPRouter install
+
+> Commit: [e17b362a94175aaab6ffc9e711e95fa80df08acc](https://github.com/dOpensource/dsiprouter/commit/e17b362a94175aaab6ffc9e711e95fa80df08acc)  
+> Date: Sun, 15 Nov 2020 04:17:36 +0000  
+> Author: root (root@testing-vm.5sbaumxjh52uxarymuyxislztd.ex.internal.cloudapp.net)  
+> Committer: root (root@testing-vm.5sbaumxjh52uxarymuyxislztd.ex.internal.cloudapp.net)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION e17b362a94175aaab6ffc9e711e95fa80df08acc)
+[//]: # (START_SECTION b04ed0097dd4ba5867062c16ec2d654e72ac6d6e)
+### Dynamically obtain the username that nginx is running under
+
+> Commit: [b04ed0097dd4ba5867062c16ec2d654e72ac6d6e](https://github.com/dOpensource/dsiprouter/commit/b04ed0097dd4ba5867062c16ec2d654e72ac6d6e)  
+> Date: Sun, 15 Nov 2020 01:17:27 +0000  
+> Author: root (root@testing-vm.4fyalwlohqaujmzfo3kwxhyerh.ex.internal.cloudapp.net)  
+> Committer: root (root@testing-vm.4fyalwlohqaujmzfo3kwxhyerh.ex.internal.cloudapp.net)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b04ed0097dd4ba5867062c16ec2d654e72ac6d6e)
+[//]: # (START_SECTION 315cbdcde908c5e94fc7f283c2b9d0c76e63f4a6)
+### Update 9.sh
+
+> Commit: [315cbdcde908c5e94fc7f283c2b9d0c76e63f4a6](https://github.com/dOpensource/dsiprouter/commit/315cbdcde908c5e94fc7f283c2b9d0c76e63f4a6)  
+> Date: Sat, 14 Nov 2020 19:38:47 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 315cbdcde908c5e94fc7f283c2b9d0c76e63f4a6)
+[//]: # (START_SECTION 7f50034e56da5e6562eb3e03c813263a5c13fbb7)
+### Update 10.sh
+
+> Commit: [7f50034e56da5e6562eb3e03c813263a5c13fbb7](https://github.com/dOpensource/dsiprouter/commit/7f50034e56da5e6562eb3e03c813263a5c13fbb7)  
+> Date: Sat, 14 Nov 2020 19:37:48 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 7f50034e56da5e6562eb3e03c813263a5c13fbb7)
+[//]: # (START_SECTION 52f64d507d7c5d867f3d8fbeb97aa52ad664ec36)
+### Updates
+
+> Commit: [52f64d507d7c5d867f3d8fbeb97aa52ad664ec36](https://github.com/dOpensource/dsiprouter/commit/52f64d507d7c5d867f3d8fbeb97aa52ad664ec36)  
+> Date: Sat, 14 Nov 2020 22:22:21 +0000  
+> Author: root (root@nightly-centos7.dsiprouter.org)  
+> Committer: root (root@nightly-centos7.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 52f64d507d7c5d867f3d8fbeb97aa52ad664ec36)
+[//]: # (START_SECTION 302a6275995e2398f18aa59ad871554456d4b68c)
+### Changed the order in which firewall rules are applied first and then firewalld is started
+
+> Commit: [302a6275995e2398f18aa59ad871554456d4b68c](https://github.com/dOpensource/dsiprouter/commit/302a6275995e2398f18aa59ad871554456d4b68c)  
+> Date: Sat, 14 Nov 2020 21:29:37 +0000  
+> Author: root (root@nightly-centos7.dsiprouter.org)  
+> Committer: root (root@nightly-centos7.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 302a6275995e2398f18aa59ad871554456d4b68c)
+[//]: # (START_SECTION 979e7f28b2c2efbf113f898b689d6603bfd274e0)
+### dSIP Documentation - Re-enabled documentation to be generated
+
+> Commit: [979e7f28b2c2efbf113f898b689d6603bfd274e0](https://github.com/dOpensource/dsiprouter/commit/979e7f28b2c2efbf113f898b689d6603bfd274e0)  
+> Date: Sat, 14 Nov 2020 19:33:28 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 979e7f28b2c2efbf113f898b689d6603bfd274e0)
+[//]: # (START_SECTION 7507cd91dffe48de1b52cd1060610332753dc890)
+### Updates to support Kamailio on CentOS
+
+> Commit: [7507cd91dffe48de1b52cd1060610332753dc890](https://github.com/dOpensource/dsiprouter/commit/7507cd91dffe48de1b52cd1060610332753dc890)  
+> Date: Sat, 14 Nov 2020 19:31:35 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 7507cd91dffe48de1b52cd1060610332753dc890)
+[//]: # (START_SECTION bad92e9378ef8164cd37f1c190f92e08ec4c5836)
+### CentOS Updated - Added kamailio-sipdump package to the installer
+
+> Commit: [bad92e9378ef8164cd37f1c190f92e08ec4c5836](https://github.com/dOpensource/dsiprouter/commit/bad92e9378ef8164cd37f1c190f92e08ec4c5836)  
+> Date: Sat, 14 Nov 2020 19:24:39 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION bad92e9378ef8164cd37f1c190f92e08ec4c5836)
+[//]: # (START_SECTION e8480a8c7036b9965c4a7424fc438aa35e4d423b)
+### Updates to support Nginx on CentOS 7
+
+> Commit: [e8480a8c7036b9965c4a7424fc438aa35e4d423b](https://github.com/dOpensource/dsiprouter/commit/e8480a8c7036b9965c4a7424fc438aa35e4d423b)  
+> Date: Sat, 14 Nov 2020 19:00:33 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION e8480a8c7036b9965c4a7424fc438aa35e4d423b)
+[//]: # (START_SECTION a2e9980ec557656d248823fc4366c7fa0f8edb24)
+### Added missing library for Sphinx
+
+> Commit: [a2e9980ec557656d248823fc4366c7fa0f8edb24](https://github.com/dOpensource/dsiprouter/commit/a2e9980ec557656d248823fc4366c7fa0f8edb24)  
+> Date: Sat, 14 Nov 2020 02:30:38 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION a2e9980ec557656d248823fc4366c7fa0f8edb24)
+[//]: # (START_SECTION 7b65855389c4be45c90bfb866eddc9451a8e1d9b)
+### Update requirements to add back in the uwsgi server
+
+> Commit: [7b65855389c4be45c90bfb866eddc9451a8e1d9b](https://github.com/dOpensource/dsiprouter/commit/7b65855389c4be45c90bfb866eddc9451a8e1d9b)  
+> Date: Sat, 14 Nov 2020 01:17:49 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 7b65855389c4be45c90bfb866eddc9451a8e1d9b)
+[//]: # (START_SECTION 16d2a8ea03bd62fbce4078450c714bab9625175d)
+### Update kamailio_dsiprouter.cfg
+
+> Commit: [16d2a8ea03bd62fbce4078450c714bab9625175d](https://github.com/dOpensource/dsiprouter/commit/16d2a8ea03bd62fbce4078450c714bab9625175d)  
+> Date: Fri, 13 Nov 2020 18:08:30 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+- Adding support for servernat
+
+
+---
+
+[//]: # (END_SECTION 16d2a8ea03bd62fbce4078450c714bab9625175d)
+[//]: # (START_SECTION 3fd6ffb00ebd98f4e93fe0e8db7a8c4121a6c670)
+### Update dsiprouter.sh
+
+> Commit: [3fd6ffb00ebd98f4e93fe0e8db7a8c4121a6c670](https://github.com/dOpensource/dsiprouter/commit/3fd6ffb00ebd98f4e93fe0e8db7a8c4121a6c670)  
+> Date: Fri, 13 Nov 2020 16:32:12 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 3fd6ffb00ebd98f4e93fe0e8db7a8c4121a6c670)
+[//]: # (START_SECTION 46667fae98f6c8b5ac627d4e0ab717413c9abb08)
+### Update kamailio_dsiprouter.cfg
+
+> Commit: [46667fae98f6c8b5ac627d4e0ab717413c9abb08](https://github.com/dOpensource/dsiprouter/commit/46667fae98f6c8b5ac627d4e0ab717413c9abb08)  
+> Date: Fri, 13 Nov 2020 16:08:42 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 46667fae98f6c8b5ac627d4e0ab717413c9abb08)
+[//]: # (START_SECTION 31515bd149e609f6f676bb357d461d6e83a01608)
+### Update kamailio_dsiprouter.cfg
+
+> Commit: [31515bd149e609f6f676bb357d461d6e83a01608](https://github.com/dOpensource/dsiprouter/commit/31515bd149e609f6f676bb357d461d6e83a01608)  
+> Date: Fri, 13 Nov 2020 15:51:28 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 31515bd149e609f6f676bb357d461d6e83a01608)
+[//]: # (START_SECTION 373b3b573a04bc6dfa83cab99bd9d881e799f741)
+### Removed Sphinx due to causing build to fail
+
+> Commit: [373b3b573a04bc6dfa83cab99bd9d881e799f741](https://github.com/dOpensource/dsiprouter/commit/373b3b573a04bc6dfa83cab99bd9d881e799f741)  
+> Date: Fri, 13 Nov 2020 20:45:24 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 373b3b573a04bc6dfa83cab99bd9d881e799f741)
+[//]: # (START_SECTION a4dff281c4621b70e411a6013293396a1b673c70)
+### Add placeholders for Docs Dirs
+
+> Commit: [a4dff281c4621b70e411a6013293396a1b673c70](https://github.com/dOpensource/dsiprouter/commit/a4dff281c4621b70e411a6013293396a1b673c70)  
+> Date: Fri, 13 Nov 2020 13:28:29 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- fix sphinx missing dir by adding placeholders
+
+
+---
+
+[//]: # (END_SECTION a4dff281c4621b70e411a6013293396a1b673c70)
+[//]: # (START_SECTION aeb39781690a8641f1164d35fe1651f1fbfe355c)
+### Added Nginx support - CentOS 7 - Debian 10
+
+> Commit: [aeb39781690a8641f1164d35fe1651f1fbfe355c](https://github.com/dOpensource/dsiprouter/commit/aeb39781690a8641f1164d35fe1651f1fbfe355c)  
+> Date: Fri, 13 Nov 2020 16:55:13 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION aeb39781690a8641f1164d35fe1651f1fbfe355c)
+[//]: # (START_SECTION 07639d4e4af2b8232ad4835ca890f2c7e1ad7414)
+### Add Rendered Docs to GUI
+
+> Commit: [07639d4e4af2b8232ad4835ca890f2c7e1ad7414](https://github.com/dOpensource/dsiprouter/commit/07639d4e4af2b8232ad4835ca890f2c7e1ad7414)  
+> Date: Fri, 13 Nov 2020 11:21:22 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- move old docs to user documentation
+- add developer docs
+- add routing docs
+- create local docs on install
+- add sphinx deps to git hooks
+
+
+---
+
+[//]: # (END_SECTION 07639d4e4af2b8232ad4835ca890f2c7e1ad7414)
+[//]: # (START_SECTION 9c97ea3d520064dde2bd147946e9181b3145dcc2)
+### Fixed permissions
+
+> Commit: [9c97ea3d520064dde2bd147946e9181b3145dcc2](https://github.com/dOpensource/dsiprouter/commit/9c97ea3d520064dde2bd147946e9181b3145dcc2)  
+> Date: Fri, 13 Nov 2020 14:50:00 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 9c97ea3d520064dde2bd147946e9181b3145dcc2)
+[//]: # (START_SECTION dd45f9e65664bc3f4bf324e6bfbd5053f4d72e99)
+### Fixed permissions - Changed kamailio_dsiprouter.cfg permissions to allow the dSIPRouter UI to access it
+
+> Commit: [dd45f9e65664bc3f4bf324e6bfbd5053f4d72e99](https://github.com/dOpensource/dsiprouter/commit/dd45f9e65664bc3f4bf324e6bfbd5053f4d72e99)  
+> Date: Fri, 13 Nov 2020 13:48:18 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION dd45f9e65664bc3f4bf324e6bfbd5053f4d72e99)
+[//]: # (START_SECTION 5b6ff83b93434abffcc48d57b1b716d5194cb2a2)
+### Changed the owner of settings.py to dsiprouter
+
+> Commit: [5b6ff83b93434abffcc48d57b1b716d5194cb2a2](https://github.com/dOpensource/dsiprouter/commit/5b6ff83b93434abffcc48d57b1b716d5194cb2a2)  
+> Date: Fri, 13 Nov 2020 00:32:25 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 5b6ff83b93434abffcc48d57b1b716d5194cb2a2)
+[//]: # (START_SECTION bf8e7fc878dd464ca797d2eea74dad58332261ca)
+### Updated dSIP version
+
+> Commit: [bf8e7fc878dd464ca797d2eea74dad58332261ca](https://github.com/dOpensource/dsiprouter/commit/bf8e7fc878dd464ca797d2eea74dad58332261ca)  
+> Date: Fri, 13 Nov 2020 00:04:09 +0000  
+> Author: root (root@nightly.dsiprouter.org)  
+> Committer: root (root@nightly.dsiprouter.org)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION bf8e7fc878dd464ca797d2eea74dad58332261ca)
+[//]: # (START_SECTION 3f3bb7416475875a443b77aa98f7f4886458c207)
+### Nginx fixes - Changed the permissions of /etc/dsiprouter/privkey to user dsiprouter
+
+> Commit: [3f3bb7416475875a443b77aa98f7f4886458c207](https://github.com/dOpensource/dsiprouter/commit/3f3bb7416475875a443b77aa98f7f4886458c207)  
+> Date: Thu, 12 Nov 2020 19:40:31 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 3f3bb7416475875a443b77aa98f7f4886458c207)
+[//]: # (START_SECTION 73ed951374c89b5aacc089e88710118f4fdfc203)
+### Update Nginx configuration
+
+> Commit: [73ed951374c89b5aacc089e88710118f4fdfc203](https://github.com/dOpensource/dsiprouter/commit/73ed951374c89b5aacc089e88710118f4fdfc203)  
+> Date: Thu, 12 Nov 2020 19:25:59 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 73ed951374c89b5aacc089e88710118f4fdfc203)
+[//]: # (START_SECTION e2c2b6d70dcad60da704a37e9800948dbbe469e2)
+### Nginx update: Issues #60
+
+> Commit: [e2c2b6d70dcad60da704a37e9800948dbbe469e2](https://github.com/dOpensource/dsiprouter/commit/e2c2b6d70dcad60da704a37e9800948dbbe469e2)  
+> Date: Thu, 12 Nov 2020 17:59:36 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION e2c2b6d70dcad60da704a37e9800948dbbe469e2)
+[//]: # (START_SECTION 9cf083098084c9e450154138455c57cc2843952f)
+### Nginx Support - Initial commit for Issue #60 - Debian 9 support
+
+> Commit: [9cf083098084c9e450154138455c57cc2843952f](https://github.com/dOpensource/dsiprouter/commit/9cf083098084c9e450154138455c57cc2843952f)  
+> Date: Thu, 12 Nov 2020 17:36:23 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 9cf083098084c9e450154138455c57cc2843952f)
+[//]: # (START_SECTION 2687815c353e29a9251ff41bdf334757d5376daf)
+### Update install.sh
+
+> Commit: [2687815c353e29a9251ff41bdf334757d5376daf](https://github.com/dOpensource/dsiprouter/commit/2687815c353e29a9251ff41bdf334757d5376daf)  
+> Date: Thu, 12 Nov 2020 10:30:35 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2687815c353e29a9251ff41bdf334757d5376daf)
+[//]: # (START_SECTION d72d5a8a07999ad84d0a1197db00e979b588f054)
+### Update dsiprouter.sh
+
+> Commit: [d72d5a8a07999ad84d0a1197db00e979b588f054](https://github.com/dOpensource/dsiprouter/commit/d72d5a8a07999ad84d0a1197db00e979b588f054)  
+> Date: Wed, 11 Nov 2020 12:40:54 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION d72d5a8a07999ad84d0a1197db00e979b588f054)
+[//]: # (START_SECTION 22cab0ab976068d4b49ecd7d4fa02e65bea4849a)
+### Update 9.sh
+
+> Commit: [22cab0ab976068d4b49ecd7d4fa02e65bea4849a](https://github.com/dOpensource/dsiprouter/commit/22cab0ab976068d4b49ecd7d4fa02e65bea4849a)  
+> Date: Wed, 11 Nov 2020 12:38:44 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 22cab0ab976068d4b49ecd7d4fa02e65bea4849a)
+[//]: # (START_SECTION 10c95ab999173de41a257a626d3cd89017b52b1f)
+### Resolves #268
+
+> Commit: [10c95ab999173de41a257a626d3cd89017b52b1f](https://github.com/dOpensource/dsiprouter/commit/10c95ab999173de41a257a626d3cd89017b52b1f)  
+> Date: Wed, 11 Nov 2020 06:38:02 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 10c95ab999173de41a257a626d3cd89017b52b1f)
+[//]: # (START_SECTION a1d693a7da90ba8eaaca8134f36260485f2f051c)
+### Fix ServerNAT Aliasing For External-Internal Address
+
+> Commit: [a1d693a7da90ba8eaaca8134f36260485f2f051c](https://github.com/dOpensource/dsiprouter/commit/a1d693a7da90ba8eaaca8134f36260485f2f051c)  
+> Date: Mon, 9 Nov 2020 17:20:44 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- add r2=on record route param to domain routing and outbound routing
+
+
+---
+
+[//]: # (END_SECTION a1d693a7da90ba8eaaca8134f36260485f2f051c)
+[//]: # (START_SECTION 9243cade3cdb3c1cbbe77a3ca0a46ef8cc593d47)
+### Update install.sh
+
+> Commit: [9243cade3cdb3c1cbbe77a3ca0a46ef8cc593d47](https://github.com/dOpensource/dsiprouter/commit/9243cade3cdb3c1cbbe77a3ca0a46ef8cc593d47)  
+> Date: Thu, 5 Nov 2020 10:12:30 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 9243cade3cdb3c1cbbe77a3ca0a46ef8cc593d47)
+[//]: # (START_SECTION dfcc241369d1b0f5abbbc163493bfbd3273bbc66)
+### Update install.sh
+
+> Commit: [dfcc241369d1b0f5abbbc163493bfbd3273bbc66](https://github.com/dOpensource/dsiprouter/commit/dfcc241369d1b0f5abbbc163493bfbd3273bbc66)  
+> Date: Thu, 5 Nov 2020 09:32:33 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION dfcc241369d1b0f5abbbc163493bfbd3273bbc66)
+[//]: # (START_SECTION 6258abfd7c1817492550798d663e3e5a5c3a54c8)
+### CentOS 8 RTPEngine Fix
+
+> Commit: [6258abfd7c1817492550798d663e3e5a5c3a54c8](https://github.com/dOpensource/dsiprouter/commit/6258abfd7c1817492550798d663e3e5a5c3a54c8)  
+> Date: Wed, 4 Nov 2020 11:29:50 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 6258abfd7c1817492550798d663e3e5a5c3a54c8)
+[//]: # (START_SECTION 247eb3fbb0690de397e3283df37eeee8dd53a6ea)
+### Update install.sh
+
+> Commit: [247eb3fbb0690de397e3283df37eeee8dd53a6ea](https://github.com/dOpensource/dsiprouter/commit/247eb3fbb0690de397e3283df37eeee8dd53a6ea)  
+> Date: Wed, 4 Nov 2020 10:35:49 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 247eb3fbb0690de397e3283df37eeee8dd53a6ea)
+[//]: # (START_SECTION 2b6ee47fc7611438ab7f2b0584cce3cf086ca6f4)
+### CentOS 8 RTPEngine
+
+> Commit: [2b6ee47fc7611438ab7f2b0584cce3cf086ca6f4](https://github.com/dOpensource/dsiprouter/commit/2b6ee47fc7611438ab7f2b0584cce3cf086ca6f4)  
+> Date: Tue, 3 Nov 2020 16:19:19 +0000  
+> Author: richard (richstorm781@gmail.com)  
+> Committer: richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2b6ee47fc7611438ab7f2b0584cce3cf086ca6f4)
+[//]: # (START_SECTION 20c240e9c512c3d4966f0f7ca4142b80e8de896f)
+### API Updated - Updated the inboundmapping API - Added a Postman collection of the API to make it easier for developers to test the API
+
+> Commit: [20c240e9c512c3d4966f0f7ca4142b80e8de896f](https://github.com/dOpensource/dsiprouter/commit/20c240e9c512c3d4966f0f7ca4142b80e8de896f)  
+> Date: Mon, 2 Nov 2020 19:31:59 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 20c240e9c512c3d4966f0f7ca4142b80e8de896f)
+[//]: # (START_SECTION 9c57c6f953bed6e9348cd47ab06a132357ddf573)
+### Update install.sh
+
+> Commit: [9c57c6f953bed6e9348cd47ab06a132357ddf573](https://github.com/dOpensource/dsiprouter/commit/9c57c6f953bed6e9348cd47ab06a132357ddf573)  
+> Date: Mon, 2 Nov 2020 12:45:04 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 9c57c6f953bed6e9348cd47ab06a132357ddf573)
+[//]: # (START_SECTION db071da5fc4d62ffcb9e97ab8b5ed4a040c01de7)
+### Update install.sh
+
+> Commit: [db071da5fc4d62ffcb9e97ab8b5ed4a040c01de7](https://github.com/dOpensource/dsiprouter/commit/db071da5fc4d62ffcb9e97ab8b5ed4a040c01de7)  
+> Date: Mon, 2 Nov 2020 11:50:11 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION db071da5fc4d62ffcb9e97ab8b5ed4a040c01de7)
+[//]: # (START_SECTION c43e91b217077be43e04f48a2d014d096f274d59)
+### Centos 8 RtpEngine fix
+
+> Commit: [c43e91b217077be43e04f48a2d014d096f274d59](https://github.com/dOpensource/dsiprouter/commit/c43e91b217077be43e04f48a2d014d096f274d59)  
+> Date: Mon, 2 Nov 2020 15:46:51 +0000  
+> Author: Richard (richstorm781@gmail.com)  
+> Committer: Richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION c43e91b217077be43e04f48a2d014d096f274d59)
+[//]: # (START_SECTION 19c08a7c0a935506b65ae130bb5c1edb214cfbbf)
+### Fixed issue with inbound calls coming from Carrier or PBX to MSTeams
+
+> Commit: [19c08a7c0a935506b65ae130bb5c1edb214cfbbf](https://github.com/dOpensource/dsiprouter/commit/19c08a7c0a935506b65ae130bb5c1edb214cfbbf)  
+> Date: Mon, 2 Nov 2020 12:00:13 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 19c08a7c0a935506b65ae130bb5c1edb214cfbbf)
+[//]: # (START_SECTION 4c4110991857ec7ecbf5f1ce0280d3057b4ed9c7)
+### Fixed issue with messages not routing back to MSTeams from a Carrier or PBX
+
+> Commit: [4c4110991857ec7ecbf5f1ce0280d3057b4ed9c7](https://github.com/dOpensource/dsiprouter/commit/4c4110991857ec7ecbf5f1ce0280d3057b4ed9c7)  
+> Date: Mon, 2 Nov 2020 10:50:17 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 4c4110991857ec7ecbf5f1ce0280d3057b4ed9c7)
+[//]: # (START_SECTION f595b16e67adcf5278e9bdcec065422cbe5c9b4b)
+### Update install.sh
+
+> Commit: [f595b16e67adcf5278e9bdcec065422cbe5c9b4b](https://github.com/dOpensource/dsiprouter/commit/f595b16e67adcf5278e9bdcec065422cbe5c9b4b)  
+> Date: Sun, 1 Nov 2020 22:39:26 -0500  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION f595b16e67adcf5278e9bdcec065422cbe5c9b4b)
+[//]: # (START_SECTION 0f60305db7c4f3476af529ea7b778540e06a9958)
+### Update install.sh
+
+> Commit: [0f60305db7c4f3476af529ea7b778540e06a9958](https://github.com/dOpensource/dsiprouter/commit/0f60305db7c4f3476af529ea7b778540e06a9958)  
+> Date: Wed, 28 Oct 2020 11:56:49 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 0f60305db7c4f3476af529ea7b778540e06a9958)
+[//]: # (START_SECTION 51efbde55b88dcd80688a6055608daa5fdb30a27)
 ### Debian 10 Fixes
 
-> Commit: [9bb6aba192ee95656f1d8cdae7c25b4b120c5c98](https://github.com/dOpensource/dsiprouter/commit/9bb6aba192ee95656f1d8cdae7c25b4b120c5c98)  
+> Commit: [51efbde55b88dcd80688a6055608daa5fdb30a27](https://github.com/dOpensource/dsiprouter/commit/51efbde55b88dcd80688a6055608daa5fdb30a27)  
 > Date: Wed, 28 Oct 2020 10:55:08 -0400  
 > Author: Tyler Moore (tmoore@goflyball.com)  
 > Committer: Tyler Moore (tmoore@goflyball.com)  
@@ -1700,7 +2524,67 @@ END_SECTION COMMITS)
 
 ---
 
-[//]: # (END_SECTION 9bb6aba192ee95656f1d8cdae7c25b4b120c5c98)
+[//]: # (END_SECTION 51efbde55b88dcd80688a6055608daa5fdb30a27)
+[//]: # (START_SECTION e7e33f0ca3224bab3d75b40cdce93d3da36ccac6)
+### Update install.sh
+
+> Commit: [e7e33f0ca3224bab3d75b40cdce93d3da36ccac6](https://github.com/dOpensource/dsiprouter/commit/e7e33f0ca3224bab3d75b40cdce93d3da36ccac6)  
+> Date: Wed, 28 Oct 2020 10:52:38 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION e7e33f0ca3224bab3d75b40cdce93d3da36ccac6)
+[//]: # (START_SECTION ed99fde349f38f1f1f5250ff4d9a02faecab9c3b)
+### Update install.sh
+
+> Commit: [ed99fde349f38f1f1f5250ff4d9a02faecab9c3b](https://github.com/dOpensource/dsiprouter/commit/ed99fde349f38f1f1f5250ff4d9a02faecab9c3b)  
+> Date: Tue, 27 Oct 2020 12:55:55 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION ed99fde349f38f1f1f5250ff4d9a02faecab9c3b)
+[//]: # (START_SECTION b3f1701f70ea9a610e81a4bc08fa5e1ff3ac9a93)
+### Update install.sh
+
+> Commit: [b3f1701f70ea9a610e81a4bc08fa5e1ff3ac9a93](https://github.com/dOpensource/dsiprouter/commit/b3f1701f70ea9a610e81a4bc08fa5e1ff3ac9a93)  
+> Date: Tue, 27 Oct 2020 11:50:15 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b3f1701f70ea9a610e81a4bc08fa5e1ff3ac9a93)
+[//]: # (START_SECTION 220ec7f1827267091059abd467b88137e717ad94)
+### Update install.sh
+
+> Commit: [220ec7f1827267091059abd467b88137e717ad94](https://github.com/dOpensource/dsiprouter/commit/220ec7f1827267091059abd467b88137e717ad94)  
+> Date: Tue, 27 Oct 2020 10:24:15 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 220ec7f1827267091059abd467b88137e717ad94)
 [//]: # (START_SECTION 8976863ab2f8aee31a6222a0010e62d9b08a3be2)
 ### Patch Pre-commit Hook
 
@@ -1717,6 +2601,21 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION 8976863ab2f8aee31a6222a0010e62d9b08a3be2)
+[//]: # (START_SECTION 2ebaca3cb6894916c37e7746e7f9b4c95473cbe0)
+### Update install.sh
+
+> Commit: [2ebaca3cb6894916c37e7746e7f9b4c95473cbe0](https://github.com/dOpensource/dsiprouter/commit/2ebaca3cb6894916c37e7746e7f9b4c95473cbe0)  
+> Date: Mon, 26 Oct 2020 15:37:14 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2ebaca3cb6894916c37e7746e7f9b4c95473cbe0)
 [//]: # (START_SECTION e3673ab836946e34bc759df32499a89bad460878)
 ### Cleaning up commits
 
@@ -1747,6 +2646,51 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION e3673ab836946e34bc759df32499a89bad460878)
+[//]: # (START_SECTION aa88b8fc61ed0bac537901196b0a7b7fedc79ad4)
+### Update 8.sh
+
+> Commit: [aa88b8fc61ed0bac537901196b0a7b7fedc79ad4](https://github.com/dOpensource/dsiprouter/commit/aa88b8fc61ed0bac537901196b0a7b7fedc79ad4)  
+> Date: Wed, 21 Oct 2020 09:27:37 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION aa88b8fc61ed0bac537901196b0a7b7fedc79ad4)
+[//]: # (START_SECTION 2c71440a60bee65291c6a88981857eb86279d958)
+### Update install.sh
+
+> Commit: [2c71440a60bee65291c6a88981857eb86279d958](https://github.com/dOpensource/dsiprouter/commit/2c71440a60bee65291c6a88981857eb86279d958)  
+> Date: Fri, 16 Oct 2020 13:17:54 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2c71440a60bee65291c6a88981857eb86279d958)
+[//]: # (START_SECTION 3525c446bb0056b05fe6745085ead8ba106403af)
+### Update install.sh
+
+> Commit: [3525c446bb0056b05fe6745085ead8ba106403af](https://github.com/dOpensource/dsiprouter/commit/3525c446bb0056b05fe6745085ead8ba106403af)  
+> Date: Fri, 16 Oct 2020 11:48:20 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 3525c446bb0056b05fe6745085ead8ba106403af)
 [//]: # (START_SECTION 02e128e74c941b83c3f8c1aea14c1387070c1393)
 ### Added the ability to handle INTERNAL MSTeams Call Transfers
 
@@ -1762,6 +2706,366 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION 02e128e74c941b83c3f8c1aea14c1387070c1393)
+[//]: # (START_SECTION 0b27f18583f624ac932f8d5cbabbd3b5407efd9f)
+### Update install.sh
+
+> Commit: [0b27f18583f624ac932f8d5cbabbd3b5407efd9f](https://github.com/dOpensource/dsiprouter/commit/0b27f18583f624ac932f8d5cbabbd3b5407efd9f)  
+> Date: Wed, 14 Oct 2020 21:57:13 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 0b27f18583f624ac932f8d5cbabbd3b5407efd9f)
+[//]: # (START_SECTION 595544e72ea35d3e85034389459821b27716520a)
+### Update settings.py
+
+> Commit: [595544e72ea35d3e85034389459821b27716520a](https://github.com/dOpensource/dsiprouter/commit/595544e72ea35d3e85034389459821b27716520a)  
+> Date: Wed, 14 Oct 2020 11:13:04 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 595544e72ea35d3e85034389459821b27716520a)
+[//]: # (START_SECTION 8697661b71b53e5dbf4e7e3755f3d6daea35248a)
+### Update cert_combined.crt
+
+> Commit: [8697661b71b53e5dbf4e7e3755f3d6daea35248a](https://github.com/dOpensource/dsiprouter/commit/8697661b71b53e5dbf4e7e3755f3d6daea35248a)  
+> Date: Wed, 14 Oct 2020 11:02:08 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 8697661b71b53e5dbf4e7e3755f3d6daea35248a)
+[//]: # (START_SECTION 2d69d1b3639238a9082d9dd1befe7b3b97fa8ad5)
+### Update cert.key
+
+> Commit: [2d69d1b3639238a9082d9dd1befe7b3b97fa8ad5](https://github.com/dOpensource/dsiprouter/commit/2d69d1b3639238a9082d9dd1befe7b3b97fa8ad5)  
+> Date: Wed, 14 Oct 2020 11:01:17 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2d69d1b3639238a9082d9dd1befe7b3b97fa8ad5)
+[//]: # (START_SECTION fc41bcee84c9a43fc507116dd63d8b62dae7fdb2)
+### Centos 8 update
+
+> Commit: [fc41bcee84c9a43fc507116dd63d8b62dae7fdb2](https://github.com/dOpensource/dsiprouter/commit/fc41bcee84c9a43fc507116dd63d8b62dae7fdb2)  
+> Date: Wed, 14 Oct 2020 14:53:33 +0000  
+> Author: richard (richstorm781@gmail.com)  
+> Committer: richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION fc41bcee84c9a43fc507116dd63d8b62dae7fdb2)
+[//]: # (START_SECTION ab07be7a8d96b82155c8447d5e73bb7df8c9e6a3)
+### Update 8.sh
+
+> Commit: [ab07be7a8d96b82155c8447d5e73bb7df8c9e6a3](https://github.com/dOpensource/dsiprouter/commit/ab07be7a8d96b82155c8447d5e73bb7df8c9e6a3)  
+> Date: Mon, 12 Oct 2020 14:53:50 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION ab07be7a8d96b82155c8447d5e73bb7df8c9e6a3)
+[//]: # (START_SECTION 333d72ebbc833e2b2424cc63a0d19b23be9cc3c7)
+### Update 8.sh
+
+> Commit: [333d72ebbc833e2b2424cc63a0d19b23be9cc3c7](https://github.com/dOpensource/dsiprouter/commit/333d72ebbc833e2b2424cc63a0d19b23be9cc3c7)  
+> Date: Mon, 12 Oct 2020 13:36:18 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 333d72ebbc833e2b2424cc63a0d19b23be9cc3c7)
+[//]: # (START_SECTION 0d97d8d35d0cb44c8ff2444964967acfbab8aaf3)
+### Update 8.sh
+
+> Commit: [0d97d8d35d0cb44c8ff2444964967acfbab8aaf3](https://github.com/dOpensource/dsiprouter/commit/0d97d8d35d0cb44c8ff2444964967acfbab8aaf3)  
+> Date: Mon, 12 Oct 2020 12:01:16 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 0d97d8d35d0cb44c8ff2444964967acfbab8aaf3)
+[//]: # (START_SECTION b6c1ba5ef380ab555007b98c54c5af03309c1042)
+### Update 8.sh
+
+> Commit: [b6c1ba5ef380ab555007b98c54c5af03309c1042](https://github.com/dOpensource/dsiprouter/commit/b6c1ba5ef380ab555007b98c54c5af03309c1042)  
+> Date: Mon, 12 Oct 2020 11:09:27 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b6c1ba5ef380ab555007b98c54c5af03309c1042)
+[//]: # (START_SECTION b89473a34ba4911150e72d636e7660763c6eb62d)
+### Update 8.sh
+
+> Commit: [b89473a34ba4911150e72d636e7660763c6eb62d](https://github.com/dOpensource/dsiprouter/commit/b89473a34ba4911150e72d636e7660763c6eb62d)  
+> Date: Mon, 12 Oct 2020 09:43:38 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b89473a34ba4911150e72d636e7660763c6eb62d)
+[//]: # (START_SECTION d9039e6c980daefce4e5e3e1acd81fc74864283c)
+### Cent0S 8 update
+
+> Commit: [d9039e6c980daefce4e5e3e1acd81fc74864283c](https://github.com/dOpensource/dsiprouter/commit/d9039e6c980daefce4e5e3e1acd81fc74864283c)  
+> Date: Fri, 9 Oct 2020 03:46:08 +0000  
+> Author: richard (richstorm781@gmail.com)  
+> Committer: richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION d9039e6c980daefce4e5e3e1acd81fc74864283c)
+[//]: # (START_SECTION 963a62c8dd0f0dea807bd2ecd041cab385e54daa)
+### Update 8.sh
+
+> Commit: [963a62c8dd0f0dea807bd2ecd041cab385e54daa](https://github.com/dOpensource/dsiprouter/commit/963a62c8dd0f0dea807bd2ecd041cab385e54daa)  
+> Date: Thu, 8 Oct 2020 11:15:42 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 963a62c8dd0f0dea807bd2ecd041cab385e54daa)
+[//]: # (START_SECTION fd2a050cb03bc8a496075f26ae7a8659739b4647)
+### Update 8.sh
+
+> Commit: [fd2a050cb03bc8a496075f26ae7a8659739b4647](https://github.com/dOpensource/dsiprouter/commit/fd2a050cb03bc8a496075f26ae7a8659739b4647)  
+> Date: Thu, 8 Oct 2020 10:47:29 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION fd2a050cb03bc8a496075f26ae7a8659739b4647)
+[//]: # (START_SECTION 69e29d707000c0414c64ee0b96530628364f0cc8)
+### Update 8.sh
+
+> Commit: [69e29d707000c0414c64ee0b96530628364f0cc8](https://github.com/dOpensource/dsiprouter/commit/69e29d707000c0414c64ee0b96530628364f0cc8)  
+> Date: Thu, 8 Oct 2020 09:39:27 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 69e29d707000c0414c64ee0b96530628364f0cc8)
+[//]: # (START_SECTION dc31e424924c5e02936096bb158b6ac210979f68)
+### Update 8.sh
+
+> Commit: [dc31e424924c5e02936096bb158b6ac210979f68](https://github.com/dOpensource/dsiprouter/commit/dc31e424924c5e02936096bb158b6ac210979f68)  
+> Date: Thu, 8 Oct 2020 09:37:13 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION dc31e424924c5e02936096bb158b6ac210979f68)
+[//]: # (START_SECTION f73c6e8e4228f1009aa4820521ca638945e9bd20)
+### Update dsiprouter.sh
+
+> Commit: [f73c6e8e4228f1009aa4820521ca638945e9bd20](https://github.com/dOpensource/dsiprouter/commit/f73c6e8e4228f1009aa4820521ca638945e9bd20)  
+> Date: Wed, 7 Oct 2020 09:51:17 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION f73c6e8e4228f1009aa4820521ca638945e9bd20)
+[//]: # (START_SECTION 62485dd6238c815d2714729fac136dc37a7770b9)
+### Update settings.py
+
+> Commit: [62485dd6238c815d2714729fac136dc37a7770b9](https://github.com/dOpensource/dsiprouter/commit/62485dd6238c815d2714729fac136dc37a7770b9)  
+> Date: Mon, 5 Oct 2020 16:46:09 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 62485dd6238c815d2714729fac136dc37a7770b9)
+[//]: # (START_SECTION b5d6c624ae39a2fe49d4107dd05af163936b4d35)
+### Update cert_combined.crt
+
+> Commit: [b5d6c624ae39a2fe49d4107dd05af163936b4d35](https://github.com/dOpensource/dsiprouter/commit/b5d6c624ae39a2fe49d4107dd05af163936b4d35)  
+> Date: Mon, 5 Oct 2020 16:45:04 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b5d6c624ae39a2fe49d4107dd05af163936b4d35)
+[//]: # (START_SECTION 61ed44cd0573769b198807e232ebc005561d62a9)
+### Update cert.key
+
+> Commit: [61ed44cd0573769b198807e232ebc005561d62a9](https://github.com/dOpensource/dsiprouter/commit/61ed44cd0573769b198807e232ebc005561d62a9)  
+> Date: Mon, 5 Oct 2020 16:43:11 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 61ed44cd0573769b198807e232ebc005561d62a9)
+[//]: # (START_SECTION 2227edd47210f18a730d6a9abefa8256e09b996c)
+### CentOS 8 support
+
+> Commit: [2227edd47210f18a730d6a9abefa8256e09b996c](https://github.com/dOpensource/dsiprouter/commit/2227edd47210f18a730d6a9abefa8256e09b996c)  
+> Date: Mon, 5 Oct 2020 20:34:23 +0000  
+> Author: Richard (richstorm781@gmail.com)  
+> Committer: Richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2227edd47210f18a730d6a9abefa8256e09b996c)
+[//]: # (START_SECTION 79c5b318678348c4e3b3fa7b19f0f784b334f0e1)
+### Update settings.py
+
+> Commit: [79c5b318678348c4e3b3fa7b19f0f784b334f0e1](https://github.com/dOpensource/dsiprouter/commit/79c5b318678348c4e3b3fa7b19f0f784b334f0e1)  
+> Date: Mon, 5 Oct 2020 15:37:15 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 79c5b318678348c4e3b3fa7b19f0f784b334f0e1)
+[//]: # (START_SECTION 3f31a4e61a2aa5e1cca17471bff1073f5652a649)
+### Update cert_combined.crt
+
+> Commit: [3f31a4e61a2aa5e1cca17471bff1073f5652a649](https://github.com/dOpensource/dsiprouter/commit/3f31a4e61a2aa5e1cca17471bff1073f5652a649)  
+> Date: Mon, 5 Oct 2020 15:30:06 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 3f31a4e61a2aa5e1cca17471bff1073f5652a649)
+[//]: # (START_SECTION d4e7eaa96c7270a12b833c6d7430db5f1cd69405)
+### Update cert.key
+
+> Commit: [d4e7eaa96c7270a12b833c6d7430db5f1cd69405](https://github.com/dOpensource/dsiprouter/commit/d4e7eaa96c7270a12b833c6d7430db5f1cd69405)  
+> Date: Mon, 5 Oct 2020 11:42:19 -0400  
+> Author: Richard Bolaji (56362787+RichSosa28@users.noreply.github.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION d4e7eaa96c7270a12b833c6d7430db5f1cd69405)
+[//]: # (START_SECTION 0aba1d2e1c1885f67df744297f296f8fa1d41202)
+### Fixed CentOS installation error
+
+> Commit: [0aba1d2e1c1885f67df744297f296f8fa1d41202](https://github.com/dOpensource/dsiprouter/commit/0aba1d2e1c1885f67df744297f296f8fa1d41202)  
+> Date: Mon, 5 Oct 2020 15:37:27 +0000  
+> Author: richard (richstorm781@gmail.com)  
+> Committer: richard (richstorm781@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 0aba1d2e1c1885f67df744297f296f8fa1d41202)
 [//]: # (START_SECTION ebea34b830e20160c547ee399b0a89a42528354d)
 ### Update settings.py
 

--- a/HA/mysql/installAAGaleraReplication.sh
+++ b/HA/mysql/installAAGaleraReplication.sh
@@ -452,7 +452,7 @@ EOF
 
                 # on CentOS mariadb fresh install doesn't have socket connection
                 # we need this to allow unix socket as fallback (parsed last in configs)
-                if ! grep -q '\[mysqld\]' /etc/my.cnf; then
+                if ! grep -q '\[mysqld\]' /etc/my.cnf 2>/dev/null; then
                     (cat <<'EOF'
 [mysqld]
 user                = mysql
@@ -527,7 +527,7 @@ EOF
 
             # on CentOS mariadb fresh install doesn't have socket connection
             # we need this to allow unix socket as fallback (parsed last in configs)
-            if ! grep -q '\[mysqld\]' /etc/my.cnf; then
+            if ! grep -q '\[mysqld\]' /etc/my.cnf 2>/dev/null; then
                 (cat <<'EOF'
 [mysqld]
 user                = mysql

--- a/HA/pacemaker/installKamCluster.sh
+++ b/HA/pacemaker/installKamCluster.sh
@@ -298,7 +298,7 @@ for NODE in ${ARGS[@]}; do
         { printerr "could not change hacluster user password"; exit 1; }
 
     # hostnames are required even if not DNS resolvable (on each node)
-    if ! grep -q -E \$(join '|' \${HOST_LIST[@]}) /etc/hosts; then
+    if ! grep -q -E \$(join '|' \${HOST_LIST[@]}) /etc/hosts 2>/dev/null; then
         i=0
         while (( \$i < \${#HOST_LIST[@]} )); do
             printf '%s\n' "\${HOST_LIST[\$i]}    \${NODE_NAMES[\$i]}" >> /etc/hosts

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -100,8 +100,7 @@ setScriptSettings() {
     export SYSTEM_RTPENGINE_CONFIG_FILE="${SYSTEM_RTPENGINE_CONFIG_DIR}/rtpengine.conf"
     export PATH_UPDATE_FILE="/etc/profile.d/dsip_paths.sh" # updates paths required
     GIT_UPDATE_FILE="/etc/profile.d/dsip_git.sh" # extends git command
-    #export RTPENGINE_VER="mr8.4.1.3"
-    export RTPENGINE_VER="mr6.1.1.1"
+    export RTPENGINE_VER="mr9.0.1.4"
     export SRC_DIR="/usr/local/src"
     export BACKUPS_DIR="/var/backups/dsiprouter"
     IMAGE_BUILD=${IMAGE_BUILD:-0}
@@ -309,15 +308,11 @@ function validateOSInfo {
         esac
     elif [[ "$DISTRO" == "centos" ]]; then
         case "$DISTRO_VER" in
-	    8)
-                if [[ -z "$KAM_VERSION" ]]; then
-                    KAM_VERSION=51
-                fi
+	        8)
+                KAM_VERSION=${KAM_VERSION:-53}
                 ;;
             7)
-                if [[ -z "$KAM_VERSION" ]]; then
-                    KAM_VERSION=51
-                fi
+                KAM_VERSION=${KAM_VERSION:-53}
                 ;;
             *)
                 printerr "Your Operating System Version is not supported yet. Please open an issue at https://github.com/dOpensource/dsiprouter/"
@@ -327,9 +322,7 @@ function validateOSInfo {
     elif [[ "$DISTRO" == "amazon" ]]; then
         case "$DISTRO_VER" in
             2)
-                if [[ -z "$KAM_VERSION" ]]; then
-                    KAM_VERSION=51
-                fi
+                KAM_VERSION=${KAM_VERSION:-51}
                 ;;
             *)
                 printerr "Your Operating System Version is not supported yet. Please open an issue at https://github.com/dOpensource/dsiprouter/"
@@ -339,9 +332,7 @@ function validateOSInfo {
     elif [[ "$DISTRO" == "ubuntu" ]]; then
         case "$DISTRO_VER" in
             16.04)
-                if [[ -z "$KAM_VERSION" ]]; then
-                    KAM_VERSION=51
-                fi
+                KAM_VERSION=${KAM_VERSION:-51}
                 ;;
             *)
                 printerr "Your Operating System Version is not supported yet. Please open an issue at https://github.com/dOpensource/dsiprouter/"
@@ -926,11 +917,11 @@ installScriptRequirements() {
 
     printdbg 'Installing one-time script requirements'
     if cmdExists 'apt-get'; then
-        DEBIAN_FRONTEND=noninteractive apt-get update -qq -y >/dev/null &&
-        DEBIAN_FRONTEND=noninteractive apt-get install -qq -y curl wget gawk perl sed git dnsutils >/dev/null
+        DEBIAN_FRONTEND=noninteractive apt-get update -y &&
+        DEBIAN_FRONTEND=noninteractive apt-get install -y curl wget gawk perl sed git dnsutils
     elif cmdExists 'yum'; then
-        yum update -y -q -e 0 >/dev/null &&
-        yum install -y -q -e 0 curl wget gawk perl sed git bind-utils >/dev/null
+        yum update -y &&
+        yum install -y curl wget gawk perl sed git bind-utils
     fi
 
     if (( $? != 0 )); then
@@ -1700,7 +1691,7 @@ function displayLoginInfo {
     local KAM_DB_USER=${KAM_DB_USER:-$(getConfigAttrib 'KAM_DB_USER' ${DSIP_CONFIG_FILE})}
     local KAM_DB_PASS=${KAM_DB_PASS:-$(decryptConfigAttrib 'KAM_DB_PASS' ${DSIP_CONFIG_FILE})}
 
-    printf '\n'
+    echo -ne '\n'
     printdbg "Your systems credentials are below (keep in a safe place)"
     pprint "dSIPRouter GUI Username: ${DSIP_USERNAME}"
     pprint "dSIPRouter GUI Password: ${DSIP_PASSWORD}"
@@ -1708,30 +1699,30 @@ function displayLoginInfo {
     pprint "dSIPRouter IPC Password: ${DSIP_IPC_PASS}"
     pprint "Kamailio DB Username: ${KAM_DB_USER}"
     pprint "Kamailio DB Password: ${KAM_DB_PASS}"
-    printf '\n'
+    echo -ne '\n'
 
     printdbg "You can access the dSIPRouter WEB GUI here"
     pprint "External IP: ${DSIP_PROTO}://${EXTERNAL_IP}:${DSIP_PORT}"
     if [ "$EXTERNAL_IP" != "$INTERNAL_IP" ];then
         pprint "Internal IP: ${DSIP_PROTO}://${INTERNAL_IP}:${DSIP_PORT}"
     fi
-    printf '\n'
+    echo -ne '\n'
 
     printdbg "You can access the dSIPRouter REST API here"
     pprint "External IP: ${DSIP_API_PROTO}://${EXTERNAL_IP}:${DSIP_PORT}"
     if [ "$EXTERNAL_IP" != "$INTERNAL_IP" ];then
         pprint "Internal IP: ${DSIP_API_PROTO}://${INTERNAL_IP}:${DSIP_PORT}"
     fi
-    printf '\n'
+    echo -ne '\n'
 
     printdbg "You can access the dSIPRouter IPC API here"
     pprint "UNIX Domain Socket: ${DSIP_IPC_SOCK}"
-    printf '\n'
+    echo -ne '\n'
 
     printdbg "You can access the Kamailio DB here"
     pprint "Database Host: ${KAM_DB_HOST}:${KAM_DB_PORT}"
     pprint "Database Name: ${KAM_DB_NAME}"
-    printf '\n'
+    echo -ne '\n'
 }
 
 # resets credentials for our services to a new random value by default

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -2489,20 +2489,28 @@ function setVerbosityLevel {
     if [[ "$*" != *"-debug"* ]]; then
         # quiet pkg managers when not debugging
         if cmdExists 'apt-get'; then
-            apt-get() {
+            function apt-get() {
                 command apt-get -qq "$@"
             }
             export -f apt-get
-        elif cmdExists 'yum'; then
-            yum() {
+        fi
+        if cmdExists 'yum'; then
+            function yum() {
                 command yum -q -e 0 "$@"
             }
             export -f yum
         fi
+        if cmdExists 'dnf'; then
+            function dnf() {
+                command dnf -q -e 0 "$@"
+            }
+            export -f dnf
+        fi
         # quiet make when not debugging
-        make() {
+        function make() {
             command make -s "$@"
         }
+        export -f make
     fi
 }
 

--- a/dsiprouter/amazon/2.sh
+++ b/dsiprouter/amazon/2.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-# import library functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
@@ -13,7 +16,7 @@ function install {
     yum --setopt=group_package_types=mandatory,default,optional groupinstall -y "Development Tools"
     yum install -y firewalld
     yum install -y python36 python36-libs python36-devel python36-pip MySQL-python
-    yum install -y logrotate rsyslog perl libev-devel util-linux
+    yum install -y logrotate rsyslog perl libev-devel util-linux postgresql-devel mariadb-devel
 
     # create dsiprouter user and group
     # sometimes locks aren't properly removed (this seems to happen often on VM's)
@@ -39,7 +42,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -68,10 +71,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -109,6 +112,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/dsiprouter/centos/7.sh
+++ b/dsiprouter/centos/7.sh
@@ -80,6 +80,7 @@ function install {
     cp -f ${DSIP_PROJECT_DIR}/resources/nginx/dsiprouter.conf /etc/nginx/conf.d
     # Configure SE Linux to allow Nginx to bind to port 5000
     semanage port -m -t http_port_t -p tcp 5000
+    systemctl enable nginx
     systemctl restart nginx
 
     # Configure rsyslog defaults

--- a/dsiprouter/centos/8.sh
+++ b/dsiprouter/centos/8.sh
@@ -60,6 +60,7 @@ function install {
     cp -f ${DSIP_PROJECT_DIR}/resources/nginx/dsiprouter.conf /etc/nginx/conf.d
     # Configure SE Linux to allow Nginx to bind to port 5000
     semanage port -m -t http_port_t -p tcp 5000
+    systemctl enable nginx
     systemctl restart nginx
 
     # Configure rsyslog defaults

--- a/dsiprouter/centos/8.sh
+++ b/dsiprouter/centos/8.sh
@@ -1,41 +1,34 @@
 #!/usr/bin/env bash
 
-#PYTHON_CMD=python3.5
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
 
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
+
 function install {
-
-    # Get the default version of python enabled
-    VER=`python -V 2>&1`
-    VER=`echo $VER | cut -d " " -f 2`
-    # Uninstall 3.6 and install a specific version of 3.6 if already installed
-    if [[ "$VER" =~ 3.6 ]]; then
-       dnf remove -y rs-epel-release
-       dnf remove -y python36 python36-devel 
-       dnf install -y https://centos8.iuscommunity.org/ius-release.rpm
-       dnf install -y python36u python36u-libs python36u-devel python36u-pip
-    elif [[ "$VER" =~ 3 ]]; then
-       dnf remove -y rs-epel-release
-       dnf remove -y python3* python3*-libs python3*-devel python3*-pip
-       dnf install -y https://centos8.iuscommunity.org/ius-release.rpm
-       dnf install -y python36u python36u-libs python36u-devel python36u-pip
-    elif [[ "$VER" =~ 2.7 ]]; then
-        dnf install -y https://centos8.iuscommunity.org/ius-release.rpm
-        dnf install -y python36u python36u-libs python36u-devel python36u-pip
-    fi
-
    # Install dependencies for dSIPRouter
     dnf install -y dnf-utils
     dnf --setopt=group_package_types=mandatory,default,optional groupinstall -y "Development Tools"
     dnf install -y firewalld nginx
-    dnf install -y python36 python36-devel 
-    dnf install -y logrotate rsyslog perl libev-devel util-linux
+    dnf install -y python36 python3-libs python36-devel python3-pip python3-mysql
+    dnf install -y logrotate rsyslog perl libev-devel util-linux postgresql-devel mariadb-devel
 
     # create dsiprouter user and group
     # sometimes locks aren't properly removed (this seems to happen often on VM's)
     rm -f /etc/passwd.lock /etc/shadow.lock /etc/group.lock /etc/gshadow.lock
     useradd --system --user-group --shell /bin/false --comment "dSIPRouter SIP Provider Platform" dsiprouter
+    usermod -a -G dsiprouter nginx
+    usermod -a -G kamailio dsiprouter
+
+    # setup /var/run/dsiprouter directory
+    mkdir -p /var/run/dsiprouter
+    chown dsiprouter:dsiprouter /var/run/dsiprouter
+
+    # allow dSIP access to the Kamailo configuration file
+    #chown dsiprouter:kamailio ${DSIP_KAMAILIO_CONFIG_FILE}
 
     # Reset python cmd in case it was just installed
     setPythonCmd
@@ -56,9 +49,18 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
+
+    # Setup uwsgi configuration
+    cp -f ${DSIP_PROJECT_DIR}/resources/uwsgi/dsiprouter.ini /etc/dsiprouter/dsiprouter.ini
+
+    # Configure Nginx
+    cp -f ${DSIP_PROJECT_DIR}/resources/nginx/dsiprouter.conf /etc/nginx/conf.d
+    # Configure SE Linux to allow Nginx to bind to port 5000
+    semanage port -m -t http_port_t -p tcp 5000
+    systemctl restart nginx
 
     # Configure rsyslog defaults
     if ! grep -q 'dSIPRouter rsyslog.conf' /etc/rsyslog.conf 2>/dev/null; then
@@ -74,7 +76,7 @@ function install {
     cp -f ${DSIP_PROJECT_DIR}/resources/logrotate/dsiprouter /etc/logrotate.d/dsiprouter
 
     # Install dSIPRouter as a service
-    perl -p -e "s|^(ExecStart\=).+?([ \t].*)|\1$PYTHON_CMD\2|;" \
+    perl -p \
         -e "s|'DSIP_RUN_DIR\=.*'|'DSIP_RUN_DIR=$DSIP_RUN_DIR'|;" \
         -e "s|'DSIP_PROJECT_DIR\=.*'|'DSIP_PROJECT_DIR=$DSIP_PROJECT_DIR'|;" \
         ${DSIP_PROJECT_DIR}/dsiprouter/dsiprouter.service > /etc/systemd/system/dsiprouter.service
@@ -90,15 +92,16 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
     dnf remove -y python36u\*
     dnf remove -y ius-release
+    dnf remove -y nginx
     dnf groupremove -y "Development Tools"
 
     # Remove the repos
@@ -131,7 +134,7 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac
 

--- a/dsiprouter/debian/10.sh
+++ b/dsiprouter/debian/10.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-# import library functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
     apt-get install -y build-essential curl python3 python3-pip python-dev python3-openssl libpq-dev firewalld nginx
     apt-get install -y --allow-unauthenticated libmariadbclient-dev 
-    apt-get install -y logrotate rsyslog perl sngrep libev-dev uuid-runtime
+    apt-get install -y logrotate rsyslog perl sngrep libev-dev uuid-runtime libpq-dev
 
     # create dsiprouter user and group
     # sometimes locks aren't properly removed (this seems to happen often on VM's)
@@ -44,7 +47,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -86,10 +89,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -122,6 +125,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/dsiprouter/debian/11.sh
+++ b/dsiprouter/debian/11.sh
@@ -1,1 +1,127 @@
-10.sh
+#!/usr/bin/env bash
+
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
+
+function install {
+    # Install dependencies for dSIPRouter
+    apt-get install -y build-essential curl python3 python3-pip python-dev python3-openssl libpq-dev firewalld nginx
+    apt-get install -y --allow-unauthenticated libmariadbclient-dev 
+    apt-get install -y logrotate rsyslog perl sngrep libev-dev uuid-runtime libpq-dev
+
+    # create dsiprouter user and group
+    # sometimes locks aren't properly removed (this seems to happen often on VM's)
+    rm -f /etc/passwd.lock /etc/shadow.lock /etc/group.lock /etc/gshadow.lock
+    useradd --system --user-group --shell /bin/false --comment "dSIPRouter SIP Provider Platform" dsiprouter
+
+    # get the user that nginx is running under. 
+    nginx_username=$(ps -o uname= -p `pidof -s nginx`)
+    # make sure the nginx user has access to dsiprouter directories
+    usermod -a -G dsiprouter $nginx_username
+    # make dsiprouter user has access to kamailio files
+    usermod -a -G kamailio dsiprouter
+
+    # setup /var/run/dsiprouter directory
+    mkdir -p /var/run/dsiprouter
+    chown dsiprouter:dsiprouter /var/run/dsiprouter
+
+    # Reset python cmd in case it was just installed
+    setPythonCmd
+
+    # Enable and start firewalld if not already running
+    systemctl enable firewalld
+    systemctl start firewalld
+
+    # Setup Firewall for DSIP_PORT
+    firewall-cmd --zone=public --add-port=${DSIP_PORT}/tcp --permanent
+    firewall-cmd --reload
+
+    PIP_CMD="pip"
+    cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
+    if [ $? -eq 1 ]; then
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
+        exit 1
+    fi
+
+   # Setup uwsgi configuration
+   cp -f ${DSIP_PROJECT_DIR}/resources/uwsgi/dsiprouter.ini /etc/dsiprouter/dsiprouter.ini
+   
+    # Configure Nginx
+    cp -f ${DSIP_PROJECT_DIR}/resources/nginx/dsiprouter /etc/nginx/sites-available
+    ln -s /etc/nginx/sites-available/dsiprouter /etc/nginx/sites-enabled
+    systemctl restart nginx  
+ 
+    # Configure rsyslog defaults
+    if ! grep -q 'dSIPRouter rsyslog.conf' /etc/rsyslog.conf 2>/dev/null; then
+        cp -f ${DSIP_PROJECT_DIR}/resources/syslog/rsyslog.conf /etc/rsyslog.conf
+    fi
+
+    # Setup dSIPRouter Logging
+    cp -f ${DSIP_PROJECT_DIR}/resources/syslog/dsiprouter.conf /etc/rsyslog.d/dsiprouter.conf
+    touch /var/log/dsiprouter.log
+    systemctl restart rsyslog
+
+    # Setup logrotate
+    cp -f ${DSIP_PROJECT_DIR}/resources/logrotate/dsiprouter /etc/logrotate.d/dsiprouter
+
+    # Install dSIPRouter as a service
+    perl -p \
+        -e "s|'DSIP_RUN_DIR\=.*'|'DSIP_RUN_DIR=$DSIP_RUN_DIR'|;" \
+        -e "s|'DSIP_PROJECT_DIR\=.*'|'DSIP_PROJECT_DIR=$DSIP_PROJECT_DIR'|;" \
+        -e "s|'DSIP_SYSTEM_CONFIG_DIR\=.*'|'DSIP_SYSTEM_CONFIG_DIR=$DSIP_SYSTEM_CONFIG_DIR'|;" \
+        ${DSIP_PROJECT_DIR}/dsiprouter/dsiprouter.service > /etc/systemd/system/dsiprouter.service
+    chmod 644 /etc/systemd/system/dsiprouter.service
+    systemctl daemon-reload
+    systemctl enable dsiprouter.service
+}
+
+function uninstall {
+    # Uninstall dependencies for dSIPRouter
+    PIP_CMD="pip"
+
+    cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
+    if [ $? -eq 1 ]; then
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        exit 1
+    else
+        printdbg "DSIPRouter uninstall was successful"
+        exit 0
+    fi
+
+    apt-get remove -y build-essential curl python3 python3-pip python-dev python3-openssl libpq-dev firewalld nginx
+    apt-get remove -y --allow-unauthenticated libmariadbclient-dev 
+    apt-get remove -y logrotate rsyslog perl sngrep libev-dev uuid-runtime
+    #apt-get remove -y build-essential curl python3 python3-pip python-dev libmariadbclient-dev libmariadb-client-lgpl-dev python-mysqldb libpq-dev firewalld
+
+    # Remove Firewall for DSIP_PORT
+    firewall-cmd --zone=public --remove-port=${DSIP_PORT}/tcp --permanent
+    firewall-cmd --reload
+
+    # Remove dSIPRouter Logging
+    rm -f /etc/rsyslog.d/dsiprouter.conf
+
+    # Remove logrotate settings
+    rm -f /etc/logrotate.d/dsiprouter
+
+    # Remove dSIProuter as a service
+    systemctl disable dsiprouter.service
+    rm -f /etc/systemd/system/dsiprouter.service
+    systemctl daemon-reload
+}
+
+case "$1" in
+    uninstall|remove)
+        uninstall
+        ;;
+    install)
+        install
+        ;;
+    *)
+        printerr "usage $0 [install | uninstall]"
+        ;;
+esac

--- a/dsiprouter/debian/7.sh
+++ b/dsiprouter/debian/7.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-# import library functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
     apt-get install -y build-essential curl python3 python3-pip python-dev libpq-dev firewalld
     apt-get install -y --allow-unauthenticated libmysqlclient-dev libmariadb-client-lgpl-dev
-    apt-get install -y logrotate rsyslog perl pandoc sngrep libev-dev uuid-runtime
+    apt-get install -y logrotate rsyslog perl pandoc sngrep libev-dev uuid-runtime libpq-dev
     easy_install3 pip
 
     # create dsiprouter user and group
@@ -31,7 +34,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -59,10 +62,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -92,6 +95,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/dsiprouter/debian/8.sh
+++ b/dsiprouter/debian/8.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-# import library functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
     apt-get install -y build-essential curl python3 python3-pip python-dev libpq-dev firewalld
     apt-get install -y --allow-unauthenticated libmysqlclient-dev libmariadb-client-lgpl-dev
-    apt-get install -y logrotate rsyslog perl pandoc sngrep libev-dev uuid-runtime
+    apt-get install -y logrotate rsyslog perl pandoc sngrep libev-dev uuid-runtime libpq-dev
     easy_install3 pip
 
     # create dsiprouter user and group
@@ -31,7 +34,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -68,10 +71,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -101,6 +104,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/dsiprouter/debian/9.sh
+++ b/dsiprouter/debian/9.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-# import library functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
     apt-get install -y build-essential curl python3 python3-pip python-dev python3-openssl libpq-dev firewalld nginx
     apt-get install -y --allow-unauthenticated libmariadbclient-dev 
-    apt-get install -y logrotate rsyslog perl sngrep libev-dev uuid-runtime
+    apt-get install -y logrotate rsyslog perl sngrep libev-dev uuid-runtime libpq-dev
 
     # create dsiprouter user and group
     # sometimes locks aren't properly removed (this seems to happen often on VM's)
@@ -48,7 +51,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -90,10 +93,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -126,6 +129,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/dsiprouter/dsip_lib.sh
+++ b/dsiprouter/dsip_lib.sh
@@ -3,64 +3,90 @@
 # NOTES:
 # contains utility functions and shared variables
 # should be sourced by an external script
+# exporting upon import removes need to import again in sub-processes
 
 ######################
 # Imported Constants #
 ######################
 
 # Ansi Colors
-ESC_SEQ="\033["
-ANSI_NONE="${ESC_SEQ}39;49;00m" # Reset colors
-ANSI_RED="${ESC_SEQ}1;31m"
-ANSI_GREEN="${ESC_SEQ}1;32m"
-ANSI_YELLOW="${ESC_SEQ}1;33m"
-ANSI_CYAN="${ESC_SEQ}1;36m"
+export ESC_SEQ="\033["
+export ANSI_NONE="${ESC_SEQ}39;49;00m" # Reset colors
+export ANSI_RED="${ESC_SEQ}1;31m"
+export ANSI_GREEN="${ESC_SEQ}1;32m"
+export ANSI_YELLOW="${ESC_SEQ}1;33m"
+export ANSI_CYAN="${ESC_SEQ}1;36m"
 
 # Constants for imported functions
-DSIP_INIT_FILE="/etc/systemd/system/dsip-init.service"
-DSIP_PROJECT_DIR=${DSIP_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}
+export DSIP_INIT_FILE="/etc/systemd/system/dsip-init.service"
+export DSIP_PROJECT_DIR=${DSIP_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}
+
+# Flag denoting that these functions have been imported (verifiable in sub-processes)
+export DSIP_LIB_IMPORTED=1
 
 ##############################################
 # Printing functions and String Manipulation #
 ##############################################
 
-printerr() {
+function printerr() {
     if [[ "$1" == "-n" ]]; then
         shift; printf "%b%s%b" "${ANSI_RED}" "$*" "${ANSI_NONE}"
     else
         printf "%b%s%b\n" "${ANSI_RED}" "$*" "${ANSI_NONE}"
     fi
 }
+export -f printerr
 
-printwarn() {
+function printwarn() {
     if [[ "$1" == "-n" ]]; then
         shift; printf "%b%s%b" "${ANSI_YELLOW}" "$*" "${ANSI_NONE}"
     else
         printf "%b%s%b\n" "${ANSI_YELLOW}" "$*" "${ANSI_NONE}"
     fi
 }
+export -f printwarn
 
-printdbg() {
+function printdbg() {
     if [[ "$1" == "-n" ]]; then
         shift; printf "%b%s%b" "${ANSI_GREEN}" "$*" "${ANSI_NONE}"
     else
         printf "%b%s%b\n" "${ANSI_GREEN}" "$*" "${ANSI_NONE}"
     fi
 }
+export -f printdbg
 
-pprint() {
+function pprint() {
     if [[ "$1" == "-n" ]]; then
         shift; printf "%b%s%b" "${ANSI_CYAN}" "$*" "${ANSI_NONE}"
     else
         printf "%b%s%b\n" "${ANSI_CYAN}" "$*" "${ANSI_NONE}"
     fi
 }
+export -f pprint
+
+function tolower() {
+    if [[ -t 0 ]]; then
+        printf '%s' "$1" | tr '[ABCDEFGHIJKLMNOPQRSTUVWXYZ]' '[abcdefghijklmnopqrstuvwxyz]'
+    else
+        tr '[ABCDEFGHIJKLMNOPQRSTUVWXYZ]' '[abcdefghijklmnopqrstuvwxyz]' </dev/stdin
+    fi
+}
+export -f tolower
+
+function toupper() {
+    if [[ -t 0 ]]; then
+        printf '%s' "$1" | tr '[abcdefghijklmnopqrstuvwxyz]' '[ABCDEFGHIJKLMNOPQRSTUVWXYZ]'
+    else
+        tr '[abcdefghijklmnopqrstuvwxyz]' '[ABCDEFGHIJKLMNOPQRSTUVWXYZ]' </dev/stdin
+    fi
+}
+export -f toupper
 
 ######################################
 # Traceback / Debug helper functions #
 ######################################
 
-backtrace() {
+function backtrace() {
     local DEPTN=${#FUNCNAME[@]}
 
     for ((i=1; i < ${DEPTN}; i++)); do
@@ -71,11 +97,13 @@ backtrace() {
         printerr "[ERROR]: ${FUNC}(), ${SRC}, line: ${LINE}"
     done
 }
+export -f backtrace
 
-setErrorTracing() {
+function setErrorTracing() {
     set -o errtrace
     trap 'backtrace' ERR
 }
+export -f setErrorTracing
 
 #######################################
 # Reusable / Shared Utility functions #
@@ -90,7 +118,7 @@ setErrorTracing() {
 # $2 == attribute value
 # $3 == python config file
 # $4 == -q (quote string) | -qb (quote byte string)
-setConfigAttrib() {
+function setConfigAttrib() {
     local NAME="$1"
     local VALUE="$2"
     local CONFIG_FILE="$3"
@@ -104,23 +132,25 @@ setConfigAttrib() {
     fi
     sed -i -r -e "s|$NAME[ \t]*=[ \t]*.*|$NAME = $VALUE|g" ${CONFIG_FILE}
 }
+export -f setConfigAttrib
 
 # $1 == attribute name
 # $2 == python config file
 # output: attribute value
-getConfigAttrib() {
+function getConfigAttrib() {
     local NAME="$1"
     local CONFIG_FILE="$2"
 
     local VALUE=$(grep -oP '^(?!#)(?:'${NAME}')[ \t]*=[ \t]*\K(?:\w+\(.*\)[ \t\v]*$|[\w\d\.]+[ \t]*$|\{.*\}|\[.*\][ \t]*$|\(.*\)[ \t]*$|b?""".*"""[ \t]*$|'"b?'''.*'''"'[ \v]*$|b?".*"[ \t]*$|'"b?'.*'"')' ${CONFIG_FILE})
     printf '%s' "${VALUE}" | perl -0777 -pe 's~^b?["'"'"']+(.*?)["'"'"']+$|(.*)~\1\2~g'
 }
+export -f getConfigAttrib
 
 # $1 == attribute name
 # $2 == python config file
 # output: attribute value decrypted
 # notes: if value is not encrypted the value is output instead
-decryptConfigAttrib() {
+function decryptConfigAttrib() {
     local NAME="$1"
     local CONFIG_FILE="$2"
     local PYTHON=${PYTHON_CMD:-python3}
@@ -133,30 +163,33 @@ decryptConfigAttrib() {
         ${PYTHON} -c "import os; os.chdir('${DSIP_PROJECT_DIR}/gui'); import settings; from util.security import AES_CTR; print(AES_CTR.decrypt(settings.${NAME}).decode('utf-8'), end='')"
     fi
 }
+export -f decryptConfigAttrib
 
 # $1 == attribute name
 # $2 == kamailio config file
-enableKamailioConfigAttrib() {
+function enableKamailioConfigAttrib() {
     local NAME="$1"
     local CONFIG_FILE="$2"
 
     sed -i -r -e "s~#+(!(define|trydef|redefine)[[:space:]]? $NAME)~#\1~g" ${CONFIG_FILE}
 }
+export -f enableKamailioConfigAttrib
 
 # $1 == attribute name
 # $2 == kamailio config file
-disableKamailioConfigAttrib() {
+function disableKamailioConfigAttrib() {
     local NAME="$1"
     local CONFIG_FILE="$2"
 
     sed -i -r -e "s~#+(!(define|trydef|redefine)[[:space:]]? $NAME)~##\1~g" ${CONFIG_FILE}
 }
+export -f disableKamailioConfigAttrib
 
 # $1 == name of defined url to change
 # $2 == value to change url to
 # $3 == kamailio config file
 # notes: will skip any cluster url attributes
-setKamailioConfigDburl() {
+function setKamailioConfigDburl() {
     local NAME="$1"
     local VALUE="$2"
     local CONFIG_FILE="$3"
@@ -164,22 +197,24 @@ setKamailioConfigDburl() {
     perl -e "\$dburl='${VALUE}';" \
         -0777 -i -pe 's~(#!(define|trydef|redefine)\s+?'"${NAME}"'\s+)['"'"'"](?!cluster\:).*['"'"'"]~\1"${dburl}"~g' ${CONFIG_FILE}
 }
+export -f setKamailioConfigDburl
 
 # $1 == name of substdef to change
 # $2 == value to change substdef to
 # $3 == kamailio config file
-setKamailioConfigSubstdef() {
+function setKamailioConfigSubstdef() {
     local NAME="$1"
     local VALUE="$2"
     local CONFIG_FILE="$3"
 
     sed -i -r -e "s~(#!substdef.*!$NAME!).*(!.*)~\1$VALUE\2~g" ${CONFIG_FILE}
 }
+export -f setKamailioConfigSubstdef
 
 # $1 == name of global variable to change
 # $2 == value to change variable to
 # $3 == kamailio config file
-setKamailioConfigGlobal() {
+function setKamailioConfigGlobal() {
     local NAME="$1"
     local VALUE="$2"
     local CONFIG_FILE="$3"
@@ -188,36 +223,40 @@ setKamailioConfigGlobal() {
     perl -pi -e "s~^(${NAME}\s?=\s?)(?:(\"|')(.*?)(\"|')|\d+)(\sdesc\s(?:\"|').*?(?:\"|'))?~\1\2${REPLACE_TOKEN}\4\5~g" ${CONFIG_FILE}
     sed -i -e "s%${REPLACE_TOKEN}%${VALUE}%g" ${CONFIG_FILE}
 }
+export -f setKamailioConfigGlobal
 
 # $1 == attribute name
 # $2 == value of attribute
 # $3 == rtpengine config file
-setRtpengineConfigAttrib() {
+function setRtpengineConfigAttrib() {
     local NAME="$1"
     local VALUE="$2"
     local CONFIG_FILE="$3"
 
     sed -i -r -e "s|(${NAME}\s?=\s?.*)|$NAME = $VALUE|g" ${CONFIG_FILE}
 }
+export -f setRtpengineConfigAttrib
 
 # output: Linux Distro name
-getDisto() {
+function getDisto() {
     cat /etc/os-release 2>/dev/null | grep '^ID=' | cut -d '=' -f 2 | cut -d '"' -f 2
 }
+export -f getDisto
 
 # $1 == command to test
 # returns: 0 == true, 1 == false
-cmdExists() {
+function cmdExists() {
     if command -v "$1" > /dev/null 2>&1; then
         return 0
     else
         return 1
     fi
 }
+export -f cmdExists
 
 # $1 == directory to check for in PATH
 # returns: 0 == found, 1 == not found
-pathCheck() {
+function pathCheck() {
     case ":${PATH-}:" in
         *:"$1":*)
             return 0
@@ -227,38 +266,43 @@ pathCheck() {
             ;;
     esac
 }
+export -f pathCheck
 
 # returns: 0 == success, otherwise failure
 # notes: try to access the AWS metadata URL to determine if this is an AMI instance
-isInstanceAMI() {
+function isInstanceAMI() {
     curl -s -f --connect-timeout 2 http://169.254.169.254/latest/dynamic/instance-identity/ &>/dev/null
     return $?
 }
+export -f isInstanceAMI
 
 # returns: 0 == success, otherwise failure
 # notes: try to access the DO metadata URL to determine if this is an Digital Ocean instance
-isInstanceDO() {
+function isInstanceDO() {
     curl -s -f --connect-timeout 2 http://169.254.169.254/metadata/v1/ &>/dev/null
     return $?
 }
+export -f isInstanceDO
 
 # returns: 0 == success, otherwise failure
 # notes: try to access the GCE metadata URL to determine if this is an Google instance
-isInstanceGCE() {
+function isInstanceGCE() {
     curl -s -f --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/ &>/dev/null
     return $?
 }
+export -f isInstanceGCE
 
 # returns: 0 == success, otherwise failure
 # notes: try to access the MS Azure metadata URL to determine if this is an Azure instance
-isInstanceAZURE() {
+function isInstanceAZURE() {
     curl -s -f --connect-timeout 2 -H "Metadata: true" "http://169.254.169.254/metadata/instance?api-version=2018-10-01" &>/dev/null
     return $?
 }
+export -f isInstanceAZURE
 
 # output: instance ID || blank string
 # notes: we try checking for exported instance variable avoid querying again
-getInstanceID() {
+function getInstanceID() {
     if (( ${AWS_ENABLED:-0} == 1)); then
         curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null ||
         ec2-metadata -i 2>/dev/null
@@ -281,23 +325,26 @@ getInstanceID() {
         fi
     fi
 }
+export -f getInstanceID
 
 # $1 == crontab entry to append
-cronAppend() {
+function cronAppend() {
     local ENTRY="$1"
     crontab -l | { cat; echo "$ENTRY"; } | crontab -
 }
+export -f cronAppend
 
 # $1 == crontab entry to remove
-cronRemove() {
+function cronRemove() {
     local ENTRY="$1"
     crontab -l | grep -v -F -w "$ENTRY" | crontab -
 }
+export -f cronRemove
 
 # $1 == ip to test
 # returns: 0 == success, 1 == failure
 # notes: regex credit to <https://helloacm.com>
-ipv4Test() {
+function ipv4Test() {
     local IP="$1"
 
     if [[ $IP =~ ^([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.([0-9]{1,2}|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$ ]]; then
@@ -305,11 +352,12 @@ ipv4Test() {
     fi
     return 1
 }
+export -f ipv4Test
 
 # $1 == ip to test
 # returns: 0 == success, 1 == failure
 # notes: regex credit to <https://helloacm.com>
-ipv6Test() {
+function ipv6Test() {
     local IP="$1"
 
     if [[ $IP =~ ^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$ ]]; then
@@ -317,6 +365,7 @@ ipv6Test() {
     fi
     return 1
 }
+export -f ipv6Test
 
 # output: the external IP for this system
 # notes: prints external ip, or empty string if not available
@@ -336,7 +385,7 @@ ipv6Test() {
 # | https://ident.me                  | 0.97620  | IPV6        |
 # | https://api6.ipify.org            | 1.08510  | IPV6        |
 #
-getExternalIP() {
+function getExternalIP() {
     local IPV6_ENABLED=${IPV6_ENABLED:-0}
     local EXTERNAL_IP=""
     local URLS=() CURL_CMD="curl"
@@ -370,11 +419,12 @@ getExternalIP() {
 
     printf '%s' "$EXTERNAL_IP"
 }
+export -f getExternalIP
 
 # $1 == cmd as executed in systemd (by ExecStart=)
 # notes: take precaution when adding long running functions as they will block startup in boot order
 # notes: adding init commands on an AMI instance must not be long running processes, otherwise they will fail
-addInitCmd() {
+function addInitCmd() {
     local CMD=$(printf '%s' "$1" | sed -e 's|[\/&]|\\&|g') # escape string
     local TMP_FILE="${DSIP_INIT_FILE}.tmp"
 
@@ -383,19 +433,21 @@ addInitCmd() {
 
     systemctl daemon-reload
 }
+export -f addInitCmd
 
 # $1 == string to match for removal (after ExecStart=)
-removeInitCmd() {
+function removeInitCmd() {
     local STR=$(printf '%s' "$1" | sed -e 's|[\/&]|\\&|g') # escape string
 
     sed -i -r "\|^ExecStart\=.*${STR}.*|d" ${DSIP_INIT_FILE}
     systemctl daemon-reload
 }
+export -f removeInitCmd
 
 # $1 == service name (full name with target) to add dependency on dsip-init service
 # notes: only adds startup ordering dependency (service continues if init fails)
 # notes: the Before= section of init will link to an After= dependency on daemon-reload
-addDependsOnInit() {
+function addDependsOnInit() {
     local SERVICE="$1"
     local TMP_FILE="${DSIP_INIT_FILE}.tmp"
 
@@ -403,33 +455,37 @@ addDependsOnInit() {
     mv -f ${TMP_FILE} ${DSIP_INIT_FILE}
     systemctl daemon-reload
 }
+export -f addDependsOnInit
 
 # $1 == service name (full name with target) to remove dependency on dsip-init service
-removeDependsOnInit() {
+function removeDependsOnInit() {
     local SERVICE="$1"
 
     sed -i "\|^Before=${SERVICE}|d" ${DSIP_INIT_FILE}
     systemctl daemon-reload
 }
+export -f removeDependsOnInit
 
 # $1 == ip or hostname
 # $2 == port
 # returns: 0 == connection good, 1 == connection bad
 # note: timeout is set to 3 sec
-checkConn() {
+function checkConn() {
     if cmdExists 'nc'; then
         nc -w 3 "$1" "$2" < /dev/null 2>&1 > /dev/null; return $?
     else
         timeout 3 bash -c "< /dev/tcp/$1/$2" 2> /dev/null; return $?
     fi
 }
+export -f checkConn
 
 # $@ == ssh command to test
 # returns: 0 == ssh connected, 1 == ssh could not connect
-checkSSH() {
+function checkSSH() {
     local SSH_CMD="$@ -o ConnectTimeout=5 -q 'exit 0'"
     bash -c "${SSH_CMD}" 2>&1 > /dev/null; return $?
 }
+export -f checkSSH
 
 # usage: checkDB [options] <database>
 # options:  --user=<mysql user>
@@ -437,7 +493,7 @@ checkSSH() {
 #           --host=<mysql host>
 #           --port=<mysql port>
 # returns:  0 if DB exists, 1 otherwise
-checkDB() {
+function checkDB() {
     local MYSQL_DBNAME=""
     local MYSQL_USER=${MYSQL_USER:-root}
     local MYSQL_PASS=${MYSQL_PASS:-}
@@ -482,6 +538,7 @@ checkDB() {
     fi
     return 1
 }
+export -f checkDB
 
 # usage: dumpDB [options] <database>
 # options:  --user=<mysql user>
@@ -490,7 +547,7 @@ checkDB() {
 #           --port=<mysql port>
 # output: dumped database as sql (redirect as needed)
 # returns: 0 on success, non zero otherwise
-dumpDB() {
+function dumpDB() {
     local MYSQL_DBNAME=""
     local MYSQL_USER=${MYSQL_USER:-root}
     local MYSQL_PASS=${MYSQL_PASS:-}
@@ -534,6 +591,7 @@ dumpDB() {
         exit ${PIPESTATUS[0]}; ) 2>/dev/null
     return $?
 }
+export -f dumpDB
 
 # usage: dumpDBUser [options] <user>@<database>
 # options:  --user=<mysql user>
@@ -542,7 +600,7 @@ dumpDB() {
 #           --port=<mysql port>
 # output: dumped database user as sql (redirect as needed)
 # returns: 0 on success, non zero otherwise
-dumpDBUser() {
+function dumpDBUser() {
     local MYSQL_DBNAME=""
     local MYSQL_DBUSER=""
     local MYSQL_USER=${MYSQL_USER:-root}
@@ -591,19 +649,21 @@ dumpDBUser() {
         exit ${PIPESTATUS[0]}; ) 2>/dev/null
     return $?
 }
+export -f dumpDBUser
 
 # $1 == number of characters to get
 # output: string of random printable characters
-urandomChars() {
+function urandomChars() {
     local LEN="$1"
     tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w ${LEN} 2>/dev/null | head -n 1
 }
+export -f urandomChars
 
 # $1 == prefix for each arg
 # $2 == delimiter between args
 # $3 == suffix for each arg
 # $@ == args to join
-joinwith() {
+function joinwith() {
     local START="$1" IFS="$2" END="$3" ARR=()
     shift;shift;shift
 
@@ -613,13 +673,14 @@ joinwith() {
 
     echo "${ARR[*]}"
 }
+export -f joinwith
 
 # $1 == rpc command
 # $@ == rpc args
 # output: output returned from kamailio
 # returns: curl return code (ref: man 1 curl)
 # note: curl will timeout after 3 seconds
-sendKamCmd() {
+function sendKamCmd() {
     local CMD="$1" PARAMS="" KAM_API_URL='http://127.0.0.1:5060/api/kamailio'
     shift
     local ARGS=("$@")
@@ -634,3 +695,4 @@ sendKamCmd() {
 
     curl -s -m 3 -X GET -d '{"method": "'"${CMD}"'", "jsonrpc": "2.0", "id": 1, "params": '"${PARAMS}"'}' ${KAM_API_URL}
 }
+export -f sendKamCmd

--- a/dsiprouter/ubuntu/16.04.sh
+++ b/dsiprouter/ubuntu/16.04.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install dependencies for dSIPRouter
     apt-get install -y build-essential curl python3 python3-pip python-dev libmysqlclient-dev libmariadb-client-lgpl-dev libpq-dev \
-        firewalld logrotate rsyslog perl libev-dev uuid-runtime
+        firewalld logrotate rsyslog perl libev-dev uuid-runtime libpq-dev
 
     # create dsiprouter user and group
     # sometimes locks aren't properly removed (this seems to happen often on VM's)
@@ -26,7 +32,7 @@ function install {
     PIP_CMD="pip"
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} install
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter install failed: Couldn't install required libraries"
+        printerr "dSIPRouter install failed: Couldn't install required libraries"
         exit 1
     fi
 
@@ -60,10 +66,10 @@ function uninstall {
 
     cat ${DSIP_PROJECT_DIR}/gui/requirements.txt | xargs -n 1 $PYTHON_CMD -m ${PIP_CMD} uninstall --yes
     if [ $? -eq 1 ]; then
-        echo "dSIPRouter uninstall failed or the libraries are already uninstalled"
+        printerr "dSIPRouter uninstall failed or the libraries are already uninstalled"
         exit 1
     else
-        echo "DSIPRouter uninstall was successful"
+        printdbg "DSIPRouter uninstall was successful"
         exit 0
     fi
 
@@ -93,6 +99,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/gui/modules/api/install.sh
+++ b/gui/modules/api/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     # Check to see if the acc table or cdr tables are in use

--- a/gui/modules/cdr/install.sh
+++ b/gui/modules/cdr/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     # Check to see if the acc table or cdr tables are in use

--- a/gui/modules/certificates/install.sh
+++ b/gui/modules/certificates/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     # Check to see if the acc table or cdr tables are in use

--- a/gui/modules/custom_routing/install.sh
+++ b/gui/modules/custom_routing/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     local TABLES=(dr_custom_rules locale_lookup)

--- a/gui/modules/domain/install.sh
+++ b/gui/modules/domain/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     local TABLES=(dsip_multidomain_mapping dsip_domain_mapping)

--- a/gui/modules/frauddetection/install.sh
+++ b/gui/modules/frauddetection/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function installSQL {
     echo ""

--- a/gui/modules/fusionpbx/install.sh
+++ b/gui/modules/fusionpbx/install.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-#set -x
-ENABLED=1 # ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# ENABLED=1 --> install, ENABLED=0 --> do nothing, ENABLED=-1 uninstall
+ENABLED=1
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     if cmdExists 'apt-get'; then

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -19,8 +19,6 @@ recommonmark
 requests
 rinohtype
 sphinx
-sphinx_rtd_theme
 sphinxcontrib-httpdomain
 SQLAlchemy
 Werkzeug
-uwsgi

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -17,8 +17,9 @@ python_crontab
 pytz
 recommonmark
 requests
-rinohtype
 sphinx
 sphinxcontrib-httpdomain
+sphinx-rtd-theme
 SQLAlchemy
+uwsgi
 Werkzeug

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -19,6 +19,8 @@ recommonmark
 requests
 rinohtype
 sphinx
+sphinx_rtd_theme
 sphinxcontrib-httpdomain
 SQLAlchemy
 Werkzeug
+uwsgi

--- a/kamailio/amazon/2.sh
+++ b/kamailio/amazon/2.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install() {
     # Install Dependencies
@@ -170,10 +176,10 @@ EOF
     firewall-cmd --reload
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -255,6 +261,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/kamailio/centos/7.sh
+++ b/kamailio/centos/7.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install() {
     # Install Dependencies
@@ -71,31 +77,15 @@ EOF
     useradd --system --user-group --shell /bin/false --comment "Kamailio SIP Proxy" kamailio
     chown -R kamailio:kamailio /var/run/kamailio
 
-    # Add the Kamailio repos to yum
-    (cat << 'EOF'
-[home_kamailio_v5.1.x-rpms]
-name=RPM Packages for Kamailio v5.1.x (CentOS_7)
-type=rpm-md
-baseurl=http://download.opensuse.org/repositories/home:/kamailio:/v5.3.x-rpms/CentOS_7/
-gpgcheck=1
-gpgkey=http://download.opensuse.org/repositories/home:/kamailio:/v5.3.x-rpms/CentOS_7/repodata/repomd.xml.key
-enabled=1
-EOF
-    ) > /etc/yum.repos.d/kamailio.repo
-
-    yum update -y
-    yum install -y kamailio kamailio-ldap kamailio-mysql kamailio-postgres kamailio-debuginfo kamailio-xmpp \
-        kamailio-unixodbc kamailio-utils kamailio-tls kamailio-presence kamailio-outbound kamailio-gzcompress \
-        kamailio-http_async_client kamailio-dmq_userloc kamailio-sipdump kamailio-websocket
-
-    # workaround for kamailio rpm transaction failures
-    if (( $? != 0 )); then
-        rpm --import $(grep 'gpgkey' /etc/yum.repos.d/kamailio.repo | cut -d '=' -f 2)
-        REPOS='kamailio kamailio-ldap kamailio-mysql kamailio-postgresql kamailio-debuginfo kamailio-xmpp kamailio-unixodbc kamailio-utils kamailio-tls kamailio-presence kamailio-outbound kamailio-gzcompress'
-        for REPO in $REPOS; do
-            yum install -y $(grep 'baseurl' /etc/yum.repos.d/kamailio.repo | cut -d '=' -f 2)$(uname -m)/$(repoquery -i ${REPO} | head -4 | tail -n 3 | tr -d '[:blank:]' | cut -d ':' -f 2 | perl -pe 'chomp if eof' | tr '\n' '-').$(uname -m).rpm
-        done
-    fi
+    KAM_REPO="kamailio-$(perl -pe 's%([0-9])(?=[0-9])%\1\.%g' <<<${KAM_VERSION})"
+    yum install -y yum-utils
+    yum-config-manager --add-repo https://rpm.kamailio.org/centos/kamailio.repo
+    rpm --import $(grep 'gpgkey' /etc/yum.repos.d/kamailio.repo | cut -d '=' -f 2 | sort -u)
+    # TODO: get the kamailio guys to fix their rpm signing
+    yum install -y --disablerepo=kamailio --enablerepo=${KAM_REPO} --nogpgcheck kamailio kamailio-ldap kamailio-mysql \
+        kamailio-postgresql kamailio-debuginfo kamailio-xmpp kamailio-unixodbc kamailio-utils kamailio-tls \
+        kamailio-presence kamailio-outbound kamailio-gzcompress kamailio-http_async_client kamailio-dmq_userloc \
+        kamailio-sipdump kamailio-websocket
 
     # get info about the kamailio install for later use in script
     KAM_VERSION_FULL=$(kamailio -v 2>/dev/null | grep '^version:' | awk '{print $3}')
@@ -167,13 +157,20 @@ EOF
         systemctl restart firewalld
     fi
 
-
+    # Setup firewall rules
+    firewall-cmd --zone=public --add-port=${KAM_SIP_PORT}/udp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_SIP_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_SIPS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_WSS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_DMQ_PORT}/udp --permanent
+    firewall-cmd --zone=public --add-port=${RTP_PORT_MIN}-${RTP_PORT_MAX}/udp
+    firewall-cmd --reload
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -255,6 +252,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/kamailio/debian/10.sh
+++ b/kamailio/debian/10.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     local KAM_SOURCES_LIST="/etc/apt/sources.list.d/kamailio.list"
@@ -84,10 +90,10 @@ EOF
     reconfigureMysqlSystemdService
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -q -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -q -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -251,6 +257,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/kamailio/debian/11.sh
+++ b/kamailio/debian/11.sh
@@ -1,1 +1,262 @@
-9.sh
+#!/usr/bin/env bash
+
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
+
+function install {
+    local KAM_SOURCES_LIST="/etc/apt/sources.list.d/kamailio.list"
+    local KAM_PREFS_CONF="/etc/apt/preferences.d/kamailio.pref"
+
+    # nf_tables is the default fw on debian but it has too many bugs at this time
+    # instead we will use legacy iptables until these issues are ironed out
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+    # Install Dependencies
+    apt-get install -y curl wget sed gawk vim perl uuid-dev libssl-dev
+    apt-get install -y logrotate rsyslog
+
+    # create kamailio user and group
+    mkdir -p /var/run/kamailio
+    # sometimes locks aren't properly removed (this seems to happen often on VM's)
+    rm -f /etc/passwd.lock /etc/shadow.lock /etc/group.lock /etc/gshadow.lock
+    useradd --system --user-group --shell /bin/false --comment "Kamailio SIP Proxy" kamailio
+    chown -R kamailio:kamailio /var/run/kamailio
+
+    # add repo sources to apt
+    mkdir -p /etc/apt/sources.list.d
+    (cat << EOF
+# kamailio repo's
+deb http://deb.kamailio.org/kamailio${KAM_VERSION} buster main
+#deb-src http://deb.kamailio.org/kamailio${KAM_VERSION} buster main
+EOF
+    ) > ${KAM_SOURCES_LIST}
+
+    # give higher precedence to packages from kamailio repo
+    mkdir -p /etc/apt/preferences.d
+    (cat << 'EOF'
+Package: *
+Pin: origin deb.kamailio.org
+Pin-Priority: 1000
+EOF
+    ) > ${KAM_PREFS_CONF}
+
+    # Add Key for Kamailio Repo
+    wget -O- http://deb.kamailio.org/kamailiodebkey.gpg | apt-key add -
+
+    # Update repo sources cache
+    apt-get update -y
+
+    # Install Kamailio packages
+    apt-get install -y --allow-unauthenticated default-mysql-server ||
+        apt-get install -y --allow-unauthenticated mariadb-server
+    apt-get install -y --allow-unauthenticated firewalld certbot kamailio kamailio-mysql-modules kamailio-extra-modules \
+        kamailio-tls-modules kamailio-websocket-modules kamailio-presence-modules
+
+    # get info about the kamailio install for later use in script
+    KAM_VERSION_FULL=$(kamailio -v 2>/dev/null | grep '^version:' | awk '{print $3}')
+    KAM_MODULES_DIR=$(find /usr/lib{32,64,}/{i386*/*,i386*/kamailio/*,x86_64*/*,x86_64*/kamailio/*,*} -name drouting.so -printf '%h' -quit 2>/dev/null)
+
+    # alias mariadb.service to mysql.service and mysqld.service as in debian repo
+    # allowing us to use same service name (mysql, mysqld, or mariadb) across platforms
+    (cat << 'EOF'
+# Add mysql Aliases by including distro script as recommended in /lib/systemd/system/mariadb.service
+.include /lib/systemd/system/mariadb.service
+[Install]
+Alias=
+Alias=mysqld.service
+Alias=mariadb.service
+EOF
+    ) > /lib/systemd/system/mysql.service
+    chmod 0644 /lib/systemd/system/mysql.service
+    (cat << 'EOF'
+# Add mysql Aliases by including distro script as recommended in /lib/systemd/system/mariadb.service
+.include /lib/systemd/system/mariadb.service
+[Install]
+Alias=
+Alias=mysql.service
+Alias=mariadb.service
+EOF
+    ) > /lib/systemd/system/mysqld.service
+    chmod 0644 /lib/systemd/system/mysqld.service
+    systemctl daemon-reload
+
+    # if db is remote don't run local service
+    reconfigureMysqlSystemdService
+
+    # Make sure MariaDB and Local DNS start before Kamailio
+    if ! grep -q -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
+        sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
+    fi
+    if ! grep -q -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
+        sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
+    fi
+    systemctl daemon-reload
+
+    # Enable MySQL and Kamailio for system startup
+    systemctl enable mysql
+    systemctl enable kamailio
+
+    # Make sure no extra configs present on fresh install
+    rm -f ~/.my.cnf
+
+    # Start MySQL
+    systemctl start mysql
+
+    # create kamailio defaults config
+    (cat << 'EOF'
+RUN_KAMAILIO=yes
+USER=kamailio
+GROUP=kamailio
+SHM_MEMORY=128
+PKG_MEMORY=16
+PIDFILE=/var/run/kamailio/kamailio.pid
+CFGFILE=/etc/kamailio/kamailio.cfg
+#DUMP_CORE=yes
+EOF
+    ) > /etc/default/kamailio
+    # create kamailio tmp files
+    echo "d /run/kamailio 0750 kamailio kamailio" > /etc/tmpfiles.d/kamailio.conf
+
+    # Configure Kamailio and Required Database Modules
+    mkdir -p ${SYSTEM_KAMAILIO_CONFIG_DIR}
+    mv -f ${SYSTEM_KAMAILIO_CONFIG_DIR}/kamctlrc ${SYSTEM_KAMAILIO_CONFIG_DIR}/kamctlrc.$(date +%Y%m%d_%H%M%S)
+    if [[ -z "${MYSQL_ROOT_PASSWORD-unset}" ]]; then
+        local ROOTPW_SETTING="DBROOTPWSKIP=yes"
+    else
+        local ROOTPW_SETTING="DBROOTPW=\"${MYSQL_ROOT_PASSWORD}\""
+    fi
+
+    # TODO: we should set STORE_PLAINTEXT_PW to 0, this is not default but would need tested
+    (cat << EOF
+DBENGINE=MYSQL
+DBHOST="${KAM_DB_HOST}"
+DBPORT="${KAM_DB_PORT}"
+DBNAME="${KAM_DB_NAME}"
+DBROUSER="${KAM_DB_USER}"
+DBROPW="${KAM_DB_PASS}"
+DBRWUSER="${KAM_DB_USER}"
+DBRWPW="${KAM_DB_PASS}"
+DBROOTUSER="${MYSQL_ROOT_USERNAME}"
+${ROOTPW_SETTING}
+CHARSET=utf8
+INSTALL_EXTRA_TABLES=yes
+INSTALL_PRESENCE_TABLES=yes
+INSTALL_DBUID_TABLES=yes
+#STORE_PLAINTEXT_PW=0
+EOF
+    ) > ${SYSTEM_KAMAILIO_CONFIG_DIR}/kamctlrc
+
+    # fix bug in kamilio v5.3.4 installer
+    if [[ "$KAM_VERSION_FULL" == "5.3.4" ]]; then
+        (cat << 'EOF'
+CREATE TABLE `secfilter` (
+`id` INT(10) UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL,
+`action` SMALLINT DEFAULT 0 NOT NULL,
+`type` SMALLINT DEFAULT 0 NOT NULL,
+`data` VARCHAR(64) DEFAULT "" NOT NULL
+);
+CREATE INDEX secfilter_idx ON secfilter (`action`, `type`, `data`);
+INSERT INTO version (table_name, table_version) values ("secfilter","1");
+EOF
+        ) > /usr/share/kamailio/mysql/secfilter-create.sql
+    fi
+
+    # Execute 'kamdbctl create' to create the Kamailio database schema
+    kamdbctl create
+
+    # Enable and start firewalld if not already running
+    systemctl enable firewalld
+    systemctl start firewalld
+
+    # Firewall settings
+    firewall-cmd --zone=public --add-port=${KAM_SIP_PORT}/udp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_SIP_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_SIPS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_WSS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --add-port=${KAM_DMQ_PORT}/udp --permanent
+    firewall-cmd --zone=public --add-port=${RTP_PORT_MIN}-${RTP_PORT_MAX}/udp
+    firewall-cmd --reload
+
+    # Configure rsyslog defaults
+    if ! grep -q 'dSIPRouter rsyslog.conf' /etc/rsyslog.conf 2>/dev/null; then
+        cp -f ${DSIP_PROJECT_DIR}/resources/syslog/rsyslog.conf /etc/rsyslog.conf
+    fi
+
+    # Setup kamailio Logging
+    cp -f ${DSIP_PROJECT_DIR}/resources/syslog/kamailio.conf /etc/rsyslog.d/kamailio.conf
+    touch /var/log/kamailio.log
+    systemctl restart rsyslog
+
+    # Setup logrotate
+    cp -f ${DSIP_PROJECT_DIR}/resources/logrotate/kamailio /etc/logrotate.d/kamailio
+
+    # Setup Kamailio to use the CA cert's that are shipped with the OS
+    mkdir -p ${DSIP_SYSTEM_CONFIG_DIR}/certs
+    cp ${DSIP_PROJECT_DIR}/kamailio/cacert_dsiprouter.pem ${DSIP_SYSTEM_CONFIG_DIR}/certs/cacert.pem
+
+    # Setup dSIPRouter Module
+    rm -rf /tmp/kamailio 2>/dev/null
+    git clone --depth 1 -b ${KAM_VERSION_FULL} https://github.com/kamailio/kamailio.git /tmp/kamailio 2>/dev/null &&
+    cp -rf ${DSIP_PROJECT_DIR}/kamailio/modules/dsiprouter/ /tmp/kamailio/src/modules/ &&
+    ( cd /tmp/kamailio/src/modules/dsiprouter; make; exit $?; ) &&
+    cp -f /tmp/kamailio/src/modules/dsiprouter/dsiprouter.so ${KAM_MODULES_DIR} ||
+    return 1
+
+    return 0
+}
+
+function uninstall {
+    # Stop and disable services
+    systemctl stop kamailio
+    systemctl stop mysql
+    systemctl disable kamailio
+    systemctl disable mysql
+
+    # Backup kamailio configuration directory
+    mv -f ${SYSTEM_KAMAILIO_CONFIG_DIR} ${SYSTEM_KAMAILIO_CONFIG_DIR}.bak.$(date +%Y%m%d_%H%M%S)
+
+    # Backup mysql / mariadb
+    mv -f /var/lib/mysql /var/lib/mysql.bak.$(date +%Y%m%d_%H%M%S)
+
+    # remove mysql unit files we created
+    rm -f /lib/systemd/system/mysql.service /lib/systemd/system/mysqld.service
+
+    # Uninstall Kamailio modules and Mariadb
+    apt-get -y remove --purge mysql\*
+    apt-get -y remove --purge mariadb\*
+    apt-get -y remove --purge kamailio\*
+    rm -rf /etc/my.cnf*; rm -f /etc/my.cnf*; rm -f ~/*my.cnf
+
+    # Remove firewall rules that was created by us:
+    firewall-cmd --zone=public --remove-port=${KAM_SIP_PORT}/udp --permanent
+    firewall-cmd --zone=public --remove-port=${KAM_SIP_PORT}/tcp --permanent
+    firewall-cmd --zone=public --remove-port=${KAM_SIPS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --remove-port=${KAM_WSS_PORT}/tcp --permanent
+    firewall-cmd --zone=public --remove-port=${KAM_DMQ_PORT}/udp --permanent
+    firewall-cmd --zone=public --remove-port=${RTP_PORT_MIN}-${RTP_PORT_MAX}/udp
+    firewall-cmd --reload
+
+    # Remove kamailio Logging
+    rm -f /etc/rsyslog.d/kamailio.conf
+
+    # Remove logrotate settings
+    rm -f /etc/logrotate.d/kamailio
+}
+
+case "$1" in
+    uninstall|remove)
+        uninstall
+        ;;
+    install)
+        install
+        ;;
+    *)
+        printerr "usage $0 [install | uninstall]"
+        ;;
+esac

--- a/kamailio/debian/7.sh
+++ b/kamailio/debian/7.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     local KAM_SOURCES_LIST="/etc/apt/sources.list.d/kamailio.list"
@@ -76,10 +82,10 @@ EOF
     reconfigureMysqlSystemdService
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -210,6 +216,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/kamailio/debian/8.sh
+++ b/kamailio/debian/8.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     local KAM_SOURCES_LIST="/etc/apt/sources.list.d/kamailio.list"
@@ -82,10 +88,10 @@ EOF
     reconfigureMysqlSystemdService
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -249,6 +255,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/kamailio/kamailio_dsiprouter.cfg
+++ b/kamailio/kamailio_dsiprouter.cfg
@@ -249,6 +249,9 @@ mpath = "/usr/lib/x86_64-linux-gnu/kamailio/modules/"
 mpath = "/usr/lib/x86_64-linux-gnu/kamailio/modules/"
 #!endif
 
+#!ifdef WITH_TLS
+loadmodule "tls.so"
+#!endif
 
 #!ifdef WITH_MYSQL
 loadmodule "db_mysql.so"
@@ -277,10 +280,10 @@ loadmodule "acc.so"
 loadmodule "xhttp.so"
 loadmodule "jsonrpcs.so"
 loadmodule "http_async_client.so"
-loadmodule "sipdump.so"
 
 # ----- sipdump params -----
 #!ifdef WITH_DEBUG_SIP
+loadmodule "sipdump.so"
 modparam("sipdump", "enable", 1)
 modparam("sipdump", "wait", 100)
 modparam("sipdump", "rotate", 3600)
@@ -331,10 +334,6 @@ loadmodule "presence_xml.so"
 #!ifdef WITH_NAT
 loadmodule "nathelper.so"
 loadmodule "rtpengine.so"
-#!endif
-
-#!ifdef WITH_TLS
-loadmodule "tls.so"
 #!endif
 
 #!ifdef WITH_ANTIFLOOD

--- a/kamailio/ubuntu/16.04.sh
+++ b/kamailio/ubuntu/16.04.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install Dependencies
@@ -68,10 +74,10 @@ EOF
     reconfigureMysqlSystemdService
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -162,10 +168,10 @@ EOF
     firewall-cmd --reload
 
     # Make sure MariaDB and Local DNS start before Kamailio
-    if ! grep -v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service; then
+    if ! grep -q v 'mysql.service dnsmasq.service' /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e 's/(After=.*)/\1 mysql.service dnsmasq.service/' /lib/systemd/system/kamailio.service
     fi
-    if ! grep -v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service; then
+    if ! grep -q v "${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig" /lib/systemd/system/kamailio.service 2>/dev/null; then
         sed -i -r -e "0,\|^ExecStart.*|{s||ExecStartPre=-${DSIP_PROJECT_DIR}/dsiprouter.sh updatednsconfig\n&|}" /lib/systemd/system/kamailio.service
     fi
     systemctl daemon-reload
@@ -245,6 +251,6 @@ case "$1" in
         install
         ;;
     *)
-        echo "usage $0 [install | uninstall]"
+        printerr "usage $0 [install | uninstall]"
         ;;
 esac

--- a/resources/git/hooks/pre-commit
+++ b/resources/git/hooks/pre-commit
@@ -29,7 +29,7 @@ EXCLUDE_DIRS=( )
 # destination file
 REQUIREMENTS_FILE="requirements.txt"
 # pipreqs only catches stdlib libraries
-INCLUDE_LIBS=('mysqlclient' 'docker' 'certbot' 'sphinx' 'recommonmark' 'sphinxcontrib-httpdomain' 'sphinx-rtd-theme')
+INCLUDE_LIBS=('mysqlclient' 'docker' 'certbot' 'sphinx' 'recommonmark' 'sphinxcontrib-httpdomain' 'sphinx-rtd-theme' 'uwsgi')
 # excludes for conflicting libs
 EXCLUDE_LIBS=('docker_py' 'pyspark' 'acme.hello' 'josepy')
 

--- a/rtpengine/amazon/install.sh
+++ b/rtpengine/amazon/install.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 # compile and install rtpengine from RPM's
 function install {
@@ -49,7 +52,7 @@ function install {
     installKernelDevHeaders
 
     if [ $? -ne 0 ]; then
-        echo "Problem with installing the required libraries for RTPEngine"
+        printerr "Problem with installing the required libraries for RTPEngine"
         exit 1
     fi
 
@@ -95,7 +98,7 @@ function install {
     fi
 
     if [ $ret -ne 0 ]; then
-        echo "Problem installing RTPEngine RPM's"
+        printerr "Problem installing RTPEngine RPM's"
         exit 1
     fi
 
@@ -109,7 +112,7 @@ function install {
     make &&
     cp -f xt_RTPENGINE.ko /lib/modules/$(uname -r)/updates/ &&
     if [ $? -ne 0 ]; then
-        echo "Problem installing RTPEngine kernel-module"
+        printerr "Problem installing RTPEngine kernel-module"
         exit 1
     fi
 
@@ -121,6 +124,10 @@ function install {
     depmod -a &&
     modprobe xt_RTPENGINE
 
+    # set the forwarding table for the kernel module
+    echo 'add 0' > /proc/rtpengine/control
+    iptables -I INPUT -p udp -j RTPENGINE --id 0
+    ip6tables -I INPUT -p udp -j RTPENGINE --id 0
 
     if [ "$SERVERNAT" == "0" ]; then
         INTERFACE=$EXTERNAL_IP
@@ -132,7 +139,7 @@ function install {
     # set table = 0 for kernel packet forwarding
     (cat << EOF
 [rtpengine]
-table = -1
+table = 0
 interface = ${INTERFACE}
 listen-ng = 127.0.0.1:7722
 port-min = ${RTP_PORT_MIN}
@@ -206,9 +213,9 @@ EOF
     # File to signify that the install happened
     if [ $? -eq 0 ]; then
         touch ${DSIP_PROJECT_DIR}/.rtpengineinstalled
-        echo "RTPEngine has been installed!"
+        printdbg "RTPEngine has been installed!"
     else
-        echo "FAILED: RTPEngine could not be installed!"
+        printerr "FAILED: RTPEngine could not be installed!"
     fi
 }
 
@@ -218,7 +225,7 @@ function uninstall {
     rm -f /usr/sbin/rtpengine
     rm -f /etc/rsyslog.d/rtpengine.conf
     rm -f /etc/logrotate.d/rtpengine
-    echo "Removed RTPEngine for $DISTRO"
+    printdbg "Removed RTPEngine for $DISTRO"
 }
 
 case "$1" in

--- a/rtpengine/centos/install.sh
+++ b/rtpengine/centos/install.sh
@@ -1,222 +1,109 @@
 #!/usr/bin/env bash
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
 
-#Get CentOS Version
-export DISTRO_VER=$(cat /etc/redhat-release | cut -d ' ' -f 4 | cut -d '.' -f 1)
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
-# compile and install rtpengine from RPM's
-if [[ "$DISTRO_VER" == "8" ]]; then
-function install {
+# Get more detailed OS info
+DISTRO=${DISTRO:-centos}
+DISTRO_VER=${DISTRO_VER:-$(cat /etc/redhat-release | cut -d ' ' -f 4 | cut -d '.' -f 1)}
+OS_VER=$(cat /etc/redhat-release | cut -d ' ' -f 4)
+OS_ARCH=$(uname -m)
+OS_KERNEL=$(uname -r)
 
-function installKernelDevHeaders {
-         local OS_VER="$(cat /etc/redhat-release | cut -d ' ' -f 4)"
-         local OS_ARCH="$(uname -m)"
-         local OS_KERNEL="$(uname -r)"
+# search for and print RPM on rpmfind.net
+# not guaranteed to find an RPM, outputs empty string if search fails
+# arguments:
+# $1 == rpm to search for
+# options:
+# -f <grep filter>
+# --filter=<grep filter>
+# TODO: add support for searching https://linuxsoft.cern.ch as well
+function rpmSearch() {
+    local RPM_SEARCH="" GREP_FILTER="" SEARCH_RESULTS=""
 
-         yum --disablerepo='*' --enablerepo=elrepo install -y kernel-devel-${OS_KERNEL} kernel-headers-${OS_KERNEL} ||
-         yum install -y https://rpmfind.net/linux/centos/${OS_VER}/updates/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-             https://rpmfind.net/linux/centos/${OS_VER}/updates/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-         yum install -y https://rpmfind.net/linux/centos/${OS_VER}/os/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-             https://rpmfind.net/linux/centos/${OS_VER}/os/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-         yum install -y https://linuxsoft.cern.ch/cern/centos/${OS_VER}/updates/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-             https://linuxsoft.cern.ch/cern/centos/${OS_VER}/updates/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-         yum install -y https://linuxsoft.cern.ch/cern/centos/${OS_VER}/os/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-             https://linuxsoft.cern.ch/cern/centos/${OS_VER}/os/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-         yum install -y http://linuxsoft.cern.ch/cern/centos/${OS_VER}/BaseOS/${OS_ARCH}/os/Packages/kernel-devel-${OS_KERNEL}.rpm \
-                        http://linuxsoft.cern.ch/cern/centos/${OS_VER}/BaseOS/${OS_ARCH}/os/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-         yum install -y http://linuxsoft.cern.ch/cern/centos/${OS_VER}/BaseOS/${OS_ARCH}/os/images/kernel-devel-${OS_KERNEL}.rpm \
-                        http://linuxsoft.cern.ch/cern/centos/${OS_VER}/BaseOS/${OS_ARCH}/os/images/kernel-headers-${OS_KERNEL}.rpm
-     }
-     
-     # Install required libraries
-     yum -y install dnf-plugins-core
-     yum config-manager --set-enabled PowerTools
-     dnf -y install https://download.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-     dnf -y localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
-     dnf -y install --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
-     dnf -y install http://rpmfind.net/linux/epel/7/x86_64/Packages/s/SDL2-2.0.10-1.el7.x86_64.rpm
-     dnf -y install ffmpeg
-     dnf -y install ffmpeg-devel
-     yum -y install mysql-devel
-     yum -y install iptables-devel kernel-devel kernel-headers xmlrpc-c xmlrpc-c-client
-     yum -y install kernel-devel
-     yum -y install glib2 glib2-devel gcc zlib zlib-devel openssl openssl-devel pcre pcre-devel libcurl libcurl-devel xmlrpc-c-devel
-     yum -y install libevent-devel glib2-devel json-glib-devel gperf gperftools-libs gperftools gperftools-devel libpcap libpcap-devel git hiredis hiredis-devel redis perl-IPC-Cmd
-     yum -y install spandsp-devel spandsp
-     yum -y install epel-release
-     yum -y install elfutils-libelf-devel gcc-toolset-9-elfutils-libelf-devel
-     rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-     rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-1.el7.nux.noarch.rpm
+    while (( $# > 0 )); do
+        # last arg is user and database
+        if (( $# == 1 )); then
+            RPM_SEARCH="$1"
+            shift
+            break
+        fi
 
-     installKernelDevHeaders
-     
-     # Make and Configure RTPEngine
-     cd /usr/local/src
-     rm -rf rtpengine/
-     git clone https://github.com/sipwise/rtpengine.git -b mr7.5.4
-     cd /usr/local/src/rtpengine/daemon/
-     make
-     cp rtpengine /usr/sbin/rtpengine
-     cd /usr/local/src/rtpengine/iptables-extension
-     make all
-     cp libxt_RTPENGINE.so /usr/lib64/xtables/.
-     
-     # ensure config dirs exist
-     mkdir -p /var/run/rtpengine ${SYSTEM_RTPENGINE_CONFIG_DIR}
-     chown -R rtpengine:rtpengine /var/run/rtpengine
-     
-     # Configure RTPEngine to support kernel packet forwarding
-     cd /usr/local/src/rtpengine/kernel-module
-     make
-     mkdir /lib/modules/$(uname -r)/extra
-     cp xt_RTPENGINE.ko /lib/modules/$(uname -r)/extra/xt_RTPENGINE.ko
-     
-     # Remove RTPEngine kernel module if previously inserted
-     if lsmod | grep 'xt_RTPENGINE'; then
-         rmmod xt_RTPENGINE
-     fi
-     # Load new RTPEngine kernel module
-     depmod -a
-     modprobe xt_RTPENGINE
-     
-     echo 'add 0' > /proc/rtpengine/control
-     iptables -I INPUT -p udp -j RTPENGINE --id 0
-     ip6tables -I INPUT -p udp -j RTPENGINE --id 0
+        case "$1" in
+            -f)
+                shift
+                GREP_FILTER="$1"
+                shift
+                ;;
+            --filter=*)
+                GREP_FILTER="$(echo "$1" | cut -d '=' -f 2)"
+                shift
+                ;;
+        esac
+    done
 
-     if [ "$SERVERNAT" == "0" ]; then
-          INTERFACE=$EXTERNAL_IP
-     else
-          INTERFACE=$INTERNAL_IP!$EXTERNAL_IP
-     fi
+    # grab the results of the search on rpmfind.net
+    SEARCH_RESULTS=$(
+        curl -sL "https://www.rpmfind.net/linux/rpm2html/search.php?query=${RPM_SEARCH}&system=${DISTRO}&arch=${OS_ARCH}" 2>/dev/null |
+            perl -e "\$rpmfind_base_url='https://rpmfind.net'; \$rpm_search='${RPM_SEARCH}'; @matches=(); " -0777 -e \
+                '$html = do { local $/; <STDIN> };
+                @matches = ($html =~ m%(?<=\<a href=["'"'"'])([-a-zA-Z0-9\@\:\%\._\+~#=/]*kernel-devel[-a-zA-Z0-9\@\:\%\._\+\~\#\=]*\.rpm)(?=["'"'"']\>)%g);
+                foreach my $match (@matches) { print "${rpmfind_base_url}${match}\n"; }' 2>/dev/null |
+            grep "${GREP_FILTER}"
+    )
 
-    # rtpengine config file
-    # set table = 0 for kernel packet forwarding
-    (cat << EOF
-[rtpengine]
-table = -1
-interface = ${INTERFACE}
-listen-ng = 127.0.0.1:7722
-port-min = ${RTP_PORT_MIN}
-port-max = ${RTP_PORT_MAX}
-log-level = 7
-log-facility = local1
-log-facility-cdr = local1
-log-facility-rtcp = local1
-EOF
-    ) > ${SYSTEM_RTPENGINE_CONFIG_FILE}
-
-    # setup rtpengine defaults file
-    (cat << 'EOF'
-RUN_RTPENGINE=yes
-CONFIG_FILE=/etc/rtpengine/rtpengine.conf
-# CONFIG_SECTION=rtpengine
-PIDFILE=/var/run/rtpengine/rtpengine.pid
-MANAGE_IPTABLES=yes
-TABLE=0
-SET_USER=rtpengine
-SET_GROUP=rtpengine
-LOG_STDERR=yes
-EOF
-    ) > /etc/default/rtpengine.conf
-
-    # Enable and start firewalld if not already running
-    systemctl enable firewalld
-    systemctl start firewalld
-
-    # Fix for bug: https://bugzilla.redhat.com/show_bug.cgi?id=1575845
-    if (( $? != 0 )); then
-        systemctl restart dbus
-        systemctl restart firewalld
-    fi
-
-    # Setup Firewall rules for RTPEngine
-    firewall-cmd --zone=public --add-port=${RTP_PORT_MIN}-${RTP_PORT_MAX}/udp --permanent
-    firewall-cmd --reload
-
-    # Setup RTPEngine Logging
-    cp -f ${DSIP_PROJECT_DIR}/resources/syslog/rtpengine.conf /etc/rsyslog.d/rtpengine.conf
-    touch /var/log/rtpengine.log
-    systemctl restart rsyslog
-
-    # Setup logrotate
-    cp -f ${DSIP_PROJECT_DIR}/resources/logrotate/rtpengine /etc/logrotate.d/rtpengine
-
-    # Setup Firewall rules for RTPEngine
-    firewall-cmd --zone=public --add-port=${RTP_PORT_MIN}-${RTP_PORT_MAX}/udp --permanent
-    firewall-cmd --reload
-
-    # Setup tmp files
-    echo "d /var/run/rtpengine.pid  0755 rtpengine rtpengine - -" > /etc/tmpfiles.d/rtpengine.conf
-    cp -f ${DSIP_PROJECT_DIR}/rtpengine/rtpengine.service /etc/systemd/system/rtpengine.service
-    cp -f ${DSIP_PROJECT_DIR}/rtpengine/rtpengine-start-pre /usr/sbin/
-    cp -f ${DSIP_PROJECT_DIR}/rtpengine/rtpengine-stop-post /usr/sbin/
-    chmod +x /usr/sbin/rtpengine*
-
-    # Reload systemd configs
-    systemctl daemon-reload
-    # Enable the RTPEngine to start during boot
-    systemctl enable rtpengine
-    # Start RTPEngine
-    systemctl start rtpengine
-
-    # Start manually if the service fails to start
-    if [ $? -ne 0 ]; then
-        /usr/sbin/rtpengine --config-file=${SYSTEM_RTPENGINE_CONFIG_FILE} --pidfile=/var/run/rtpengine/rtpengine.pid
-    fi
-
-    # File to signify that the install happened
-    if [ $? -eq 0 ]; then
-        touch ${DSIP_PROJECT_DIR}/.rtpengineinstalled
-        echo "RTPEngine has been installed!"
-    else
-        echo "FAILED: RTPEngine could not be installed!"
+    # check if the results are archived and update results if so
+    if [[ -n "$SEARCH_RESULTS" ]]; then
+        for RPM in $(echo "$SEARCH_RESULTS"); do
+            if [[ "$(curl -ksLI -o /dev/null -w '%{http_code}' "${RPM}")" != "200" ]]; then
+                perl -pe 's%https://rpmfind.net/linux/centos(.*)%https://vault.centos.org\1%' <<<"${RPM}"
+            else
+                echo "${RPM}"
+            fi
+        done
     fi
 }
 
-elif [[ "$DISTRO_VER" == "7" ]]; then
+# compile and install rtpengine from RPM's
 function install {
-    local VERSION_NUM=""
+    local RTPENGINE_RPM_VER=""
 
     # try installing in the following order:
     # 1: headers from repos
-    # 2: headers from rpmfind.net (updates branch)
-    # 3: headers from rpmfind.net (os branch)
-    # 4: headers from linuxsoft.cern.ch (updates branch)
-    # 5: headers from linuxsoft.cern.ch (os branch)
+    # 2: headers from rpmfind.net
     function installKernelDevHeaders {
-        local OS_VER="$(cat /etc/redhat-release | cut -d ' ' -f 4)"
-        local OS_ARCH="$(uname -m)"
-        local OS_KERNEL="$(uname -r)"
-
         yum install -y kernel-devel-${OS_KERNEL} kernel-headers-${OS_KERNEL} ||
-        yum install -y https://rpmfind.net/linux/centos/7/updates/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-            https://rpmfind.net/linux/centos/7/updates/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-        yum install -y https://rpmfind.net/linux/centos/7/os/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-            https://rpmfind.net/linux/centos/7/os/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-        yum install -y https://linuxsoft.cern.ch/cern/centos/7/updates/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-            https://linuxsoft.cern.ch/cern/centos/7/updates/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm ||
-        yum install -y https://linuxsoft.cern.ch/cern/centos/7/os/${OS_ARCH}/Packages/kernel-devel-${OS_KERNEL}.rpm \
-            https://linuxsoft.cern.ch/cern/centos/7/os/${OS_ARCH}/Packages/kernel-headers-${OS_KERNEL}.rpm
+            yum install -y $(rpmSearch -f kernel-devel-${OS_KERNEL} kernel-devel) $(rpmSearch -f kernel-headers-${OS_KERNEL} kernel-headers)
     }
 
     # Install required libraries
     yum install -y epel-release
-    yum install -y logrotate rsyslog bc
-    rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-    rpm -Uh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release-0-5.el7.nux.noarch.rpm
-    yum install -y gcc glib2 glib2-devel zlib zlib-devel openssl openssl-devel pcre pcre-devel libcurl libcurl-devel \
+    if (( ${DISTRO_VER} >= 8 )); then
+        yum install -y dnf-plugins-core dnf-utils
+        yum config-manager --set-enabled PowerTools
+        yum-config-manager --add-repo=https://negativo17.org/repos/epel-multimedia.repo
+        dnf install -y ffmpeg ffmpeg-devel
+        #yum -y install gperf gperftools-libs gperftools gperftools-devel
+        #yum -y install elfutils-libelf-devel gcc-toolset-9-elfutils-libelf-devel
+    else
+        rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
+        rpm -Uh http://li.nux.ro/download/nux/dextop/el${DISTRO_VER}/${OS_ARCH}/nux-dextop-release-0-5.el${DISTRO_VER}.nux.noarch.rpm
+        yum install -y ffmpeg ffmpeg-devel
+    fi
+    yum install -y gcc glib2 glib2-devel zlib zlib-devel openssl openssl-devel pcre pcre-devel libcurl libcurl-devel mariadb-devel \
         xmlrpc-c xmlrpc-c-devel libpcap libpcap-devel hiredis hiredis-devel json-glib json-glib-devel libevent libevent-devel \
-        iptables-devel xmlrpc-c-devel ffmpeg ffmpeg-devel gperf redhat-lsb iptables-ipv6 nc dkms perl perl-IPC-Cmd spandsp-devel
-    yum install -y redhat-rpm-config rpm-build pkgconfig
+        iptables iptables-devel xmlrpc-c-devel gperf redhat-lsb nc dkms perl perl-IPC-Cmd spandsp spandsp-devel logrotate rsyslog bc \
+        redhat-rpm-config rpm-build pkgconfig perl-Config-Tiny gperf gperftools-libs gperftools gperftools-devel
 
     installKernelDevHeaders
 
-    if [ $? -ne 0 ]; then
-        echo "Problem with installing the required libraries for RTPEngine"
+    if (( $? != 0 )); then
+        printerr "Problem with installing the required libraries for RTPEngine"
         exit 1
     fi
 
@@ -224,7 +111,7 @@ function install {
     # allowing rsyslog to be accessible via syslog namespace
     # the settings are already there just commented out by default
     sed -i -r 's|^[;#](.*)|\1|g' /usr/lib/systemd/system/rsyslog.service
-    ln -s /usr/lib/systemd/system/rsyslog.service /etc/systemd/system/syslog.service
+    ln -sf /usr/lib/systemd/system/rsyslog.service /etc/systemd/system/syslog.service
     systemctl daemon-reload
 
     # create rtpengine user and group
@@ -239,30 +126,33 @@ function install {
     git clone https://github.com/sipwise/rtpengine.git -b ${RTPENGINE_VER}
     cd ./rtpengine
 
-    VERSION_NUM=$(grep -oP 'Version:.+?\K[\w\.\~\+]+' ./el/rtpengine.spec)
+    RTPENGINE_RPM_VER=$(grep -oP 'Version:.+?\K[\w\.\~\+]+' ./el/rtpengine.spec)
     if (( $(echo "$RTPENGINE_VER" | perl -0777 -pe 's|mr(\d+\.\d+)\.(\d+)\.(\d+)|\1\2\3 >= 6.511|gm' | bc -l) )); then
-        PREFIX="rtpengine-${VERSION_NUM}/"
+        PREFIX="rtpengine-${RTPENGINE_RPM_VER}/"
     else
-        PREFIX="ngcp-rtpengine-${VERSION_NUM}/"
+        PREFIX="ngcp-rtpengine-${RTPENGINE_RPM_VER}/"
     fi
 
-    mkdir -p ~/rpmbuild/SOURCES
-
-    git archive --output ~/rpmbuild/SOURCES/ngcp-rtpengine-${VERSION_NUM}.tar.gz --prefix=${PREFIX} ${RTPENGINE_VER}
-    rpmbuild -ba  ./el/rtpengine.spec
-    rpm -i ~/rpmbuild/RPMS/$(uname -m)/ngcp-rtpengine-${VERSION_NUM}*.rpm
+    RPM_BUILD_ROOT="${HOME}/rpmbuild"
+    rm -rf ${RPM_BUILD_ROOT}
+    mkdir -p ${RPM_BUILD_ROOT}/SOURCES
+    git archive --output ${RPM_BUILD_ROOT}/SOURCES/ngcp-rtpengine-${RTPENGINE_RPM_VER}.tar.gz --prefix=${PREFIX} ${RTPENGINE_VER}
+    # fix for rpm build path issue
+    perl -i -pe 's|(%define archname) rtpengine-mr|\1 rtpengine-|' ./el/rtpengine.spec
+    rpmbuild -ba ./el/rtpengine.spec
+    rpm -i ${RPM_BUILD_ROOT}/RPMS/${OS_ARCH}/ngcp-rtpengine-${RTPENGINE_RPM_VER}*.rpm
     rpm -q ngcp-rtpengine >/dev/null 2>&1; ret=$?
-    rpm -i ~/rpmbuild/RPMS/noarch/ngcp-rtpengine-dkms-${VERSION_NUM}*.rpm
+    rpm -i ${RPM_BUILD_ROOT}/RPMS/noarch/ngcp-rtpengine-dkms-${RTPENGINE_RPM_VER}*.rpm
     rpm -q ngcp-rtpengine-dkms >/dev/null 2>&1; ((ret+=$?))
-    rpm -i ~/rpmbuild/RPMS/$(uname -m)/ngcp-rtpengine-kernel-${VERSION_NUM}*.rpm
+    rpm -i ${RPM_BUILD_ROOT}/RPMS/${OS_ARCH}/ngcp-rtpengine-kernel-${RTPENGINE_RPM_VER}*.rpm
     rpm -q ngcp-rtpengine-kernel >/dev/null 2>&1; ((ret+=$?))
-    if [ -f ~/rpmbuild/RPMS/$(uname -m)/ngcp-rtpengine-recording-${VERSION_NUM}*.rpm ]; then
-        rpm -i ~/rpmbuild/RPMS/$(uname -m)/ngcp-rtpengine-recording-${VERSION_NUM}*.rpm
+    if [ -f ${RPM_BUILD_ROOT}/RPMS/${OS_ARCH}/ngcp-rtpengine-recording-${RTPENGINE_RPM_VER}*.rpm ]; then
+        rpm -i ${RPM_BUILD_ROOT}/RPMS/${OS_ARCH}/ngcp-rtpengine-recording-${RTPENGINE_RPM_VER}*.rpm
         rpm -q ngcp-rtpengine-recording >/dev/null 2>&1; ((ret+=$?))
     fi
 
-    if [ $ret -ne 0 ]; then
-        echo "Problem installing RTPEngine RPM's"
+    if (( $ret != 0 )); then
+        printerr "Problem installing RTPEngine RPM's"
         exit 1
     fi
 
@@ -276,7 +166,7 @@ function install {
     make &&
     cp -f xt_RTPENGINE.ko /lib/modules/$(uname -r)/updates/ &&
     if [ $? -ne 0 ]; then
-        echo "Problem installing RTPEngine kernel-module"
+        printerr "Problem installing RTPEngine kernel-module"
         exit 1
     fi
 
@@ -288,6 +178,10 @@ function install {
     depmod -a &&
     modprobe xt_RTPENGINE
 
+    # set the forwarding table for the kernel module
+    echo 'add 0' > /proc/rtpengine/control
+    iptables -I INPUT -p udp -j RTPENGINE --id 0
+    ip6tables -I INPUT -p udp -j RTPENGINE --id 0
 
     if [ "$SERVERNAT" == "0" ]; then
         INTERFACE=$EXTERNAL_IP
@@ -299,7 +193,7 @@ function install {
     # set table = 0 for kernel packet forwarding
     (cat << EOF
 [rtpengine]
-table = -1
+table = 0
 interface = ${INTERFACE}
 listen-ng = 127.0.0.1:7722
 port-min = ${RTP_PORT_MIN}
@@ -373,14 +267,11 @@ EOF
     # File to signify that the install happened
     if [ $? -eq 0 ]; then
         touch ${DSIP_PROJECT_DIR}/.rtpengineinstalled
-        echo "RTPEngine has been installed!"
+        printdbg "RTPEngine has been installed!"
     else
-        echo "FAILED: RTPEngine could not be installed!"
+        printerr "FAILED: RTPEngine could not be installed!"
     fi
 }
-else
-echo "Invalid CentOS Version"
-fi
     
 # Remove RTPEngine
 function uninstall {
@@ -388,7 +279,7 @@ function uninstall {
     rm -f /usr/sbin/rtpengine
     rm -f /etc/rsyslog.d/rtpengine.conf
     rm -f /etc/logrotate.d/rtpengine
-    echo "Removed RTPEngine for $DISTRO"
+    printdbg "Removed RTPEngine for $DISTRO"
 }
 
 case "$1" in

--- a/rtpengine/ubuntu/install.sh
+++ b/rtpengine/ubuntu/install.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-# Import dsip_lib utility / shared functions
-. ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
-
+# Debug this script if in debug mode
 (( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
 
 function install {
     # Install required libraries
@@ -72,13 +75,18 @@ function install {
     dpkg -i ngcp-rtpengine-kernel-dkms_*
 
     if [ $? -ne 0 ]; then
-        echo "Problem installing RTPEngine DEB's"
+        printerr "Problem installing RTPEngine DEB's"
         exit 1
     fi
 
     # ensure config dirs exist
     mkdir -p /var/run/rtpengine ${SYSTEM_RTPENGINE_CONFIG_DIR}
     chown -R rtpengine:rtpengine /var/run/rtpengine
+
+    # set the forwarding table for the kernel module
+    echo 'add 0' > /proc/rtpengine/control
+    iptables -I INPUT -p udp -j RTPENGINE --id 0
+    ip6tables -I INPUT -p udp -j RTPENGINE --id 0
 
     if [ "$SERVERNAT" == "0" ]; then
         INTERFACE=$EXTERNAL_IP
@@ -90,7 +98,7 @@ function install {
     # set table = 0 for kernel packet forwarding
     (cat << EOF
 [rtpengine]
-table = -1
+table = 0
 interface = ${INTERFACE}
 listen-ng = 127.0.0.1:7722
 port-min = ${RTP_PORT_MIN}
@@ -155,10 +163,10 @@ EOF
 
     # File to signify that the install happened
     if [ $? -eq 0 ]; then
-       touch ${DSIP_PROJECT_DIR}/.rtpengineinstalled
-       echo "RTPEngine has been installed!"
+        touch ${DSIP_PROJECT_DIR}/.rtpengineinstalled
+        printdbg "RTPEngine has been installed!"
     else
-        echo "FAILED: RTPEngine could not be installed!"
+        printerr "FAILED: RTPEngine could not be installed!"
     fi
 }
 
@@ -168,7 +176,7 @@ function uninstall {
     rm -f /usr/sbin/rtpengine
     rm -f /etc/rsyslog.d/rtpengine.conf
     rm -f /etc/logrotate.d/rtpengine
-    echo "Removed RTPEngine for $DISTRO"
+    printdbg "Removed RTPEngine for $DISTRO"
 }
 
 case "$1" in


### PR DESCRIPTION
  - fix psycopg2 dependency issue on centos
  - fix flask dependency issue on centos
  - fixup printing commands in sub-processes
  - fix kernel header lookups for rtpengine install
  - fixup centos rtpengine install code
  - change rtpengine to use kernel packet forwarding by default
  - improve efficiency by exporting sub-process required funcs
  - update rtpengine version to latest release
  - add nginx changes to centos8
  - update centos to use kamailio 5.3
  - fixed grep file checks outputting text during install
  - add some utility functions to `dsip_lib.sh`
  - revert centos8 to using mariadb instead of mysql
  - fix dependency conflicts between mysql-common and mariadb-common
  - fix centos8 python dependencies
  - various fixes for centos8 service install scripts