### PR TITLE
fix broken rsyslog.service - only remove ; comment tags

### DIFF
--- a/rtpengine/centos/install.sh
+++ b/rtpengine/centos/install.sh
@@ -120,7 +120,7 @@ function install {
     # alias and link rsyslog to syslog service as in debian
     # allowing rsyslog to be accessible via syslog namespace
     # the settings are already there just commented out by default
-    sed -i -r 's|^[;#](.*)|\1|g' /usr/lib/systemd/system/rsyslog.service
+    sed -i -r 's|^[;](.*)|\1|g' /usr/lib/systemd/system/rsyslog.service
     ln -sf /usr/lib/systemd/system/rsyslog.service /etc/systemd/system/syslog.service
     systemctl daemon-reload
 


### PR DESCRIPTION
Disable removing "#" comments tags and only remove ";" comment tags instead, otherwise, installing RTPENGINE under CentOS breaks rsyslog.service

By the way, dsiprouter logging is still broken even after this fix, I suspect there is another issue, possible with sysloginit.py  but have not been able to figure out yet.