### PR TITLE
fix #418 itsdangerous version incompatibility

### DIFF
--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -7,7 +7,7 @@ docker
 Flask==1.1.2
 Flask_Script
 Flask_WTF
-itsdangerous
+itsdangerous==2.0.1
 mysqlclient
 pem
 psycopg2


### PR DESCRIPTION
Fix error itsdangerous==2.1.0 version with Flask==1.1.2, setting itsdangerous==2.0.1