### PR TITLE
Removed EOL PoPs

### DIFF
--- a/docs/source/user/debian_install.rst
+++ b/docs/source/user/debian_install.rst
@@ -13,7 +13,7 @@ Install (Proxy audio (RTP) traffic)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code-block:: bash
 
-  hostnamectl set-hostname 
+  hostnamectl set-hostname <YOUR.DOMAINNAME.COM>
   apt update && apt install -y git curl
   cd /opt
   git clone https://github.com/dOpensource/dsiprouter -b master dsiprouter

--- a/docs/source/user/global_outbound_routes.rst
+++ b/docs/source/user/global_outbound_routes.rst
@@ -32,6 +32,27 @@ Global Outbound Routes
   a) Enter in the Outbound Route information.
   b) Click on the green Add button.
 
+  From Prefix:
+    This is matched against the SIP From: header. The from header typically contains the SIP Username.
+    You can specify a prefix here to tell dSIPRouter to use the specified Carrier Group on a match.
+
+  To Prefix:
+    This is matched against the SIP To: header. Depending on your PBX deployments, you may wish to have
+    your clients prefix their outbound calls with a custom 'prefix'. This can be used to provide an extra
+    layer of security for IP Authenticated calls. (Much like Flowroutes' TechPrefix.
+    Specifcy a prefix here only if you expect to receive a prefix from your client.
+  
+  Recurring Time:
+    Unknown at this time.
+    
+  Custome Kamaillio Route:
+    This currently does not have an option to provide custom routes.
+  
+  Carrier Group:
+    Specify the Carrier Group you wish to use to deliever calls made to this outbound route.
+    You may want to create additional custom Carrier Groups, perhaps with different failover providers listed, to 
+    provide a redundant failover.
+    
 .. image:: images//dSIP_Global_Out_Add_Outbound_Route.png
         :align: center
         

--- a/kamailio/defaults/address.csv
+++ b/kamailio/defaults/address.csv
@@ -20,9 +20,7 @@ null;FLT_CARRIER;52.8.201.128;32;0;name:Skyetel 3rd Priority Outbound Call,gwgro
 null;FLT_CARRIER;50.17.48.216;32;0;name:Skyetel 4rd Priority Outbound Call,gwgroup:2
 null;FLT_CARRIER;52.32.223.28;32;0;name:Skyetel North West High Cost Outbound Traffic,gwgroup:2
 null;FLT_CARRIER;52.4.178.107;32;0;name:Skyetel South East High Cost Outbound Traffic,gwgroup:2
-null;FLT_CARRIER;147.75.60.160;32;0;name:Flowroute US-West-WA,gwgroup:3
 null;FLT_CARRIER;34.210.91.112;32;0;name:Flowroute US-West-OR,gwgroup:3
-null;FLT_CARRIER;147.75.65.192;32;0;name:Flowroute US-East-NJ,gwgroup:3
 null;FLT_CARRIER;34.226.36.32;32;0;name:Flowroute US-East-VA,gwgroup:3
 null;FLT_CARRIER;81.201.82.45;32;0;name:Voxbone Belgium,gwgroup:4
 null;FLT_CARRIER;81.201.84.195;32;0;name:Voxbone LA,gwgroup:4

--- a/kamailio/defaults/dr_gateways.csv
+++ b/kamailio/defaults/dr_gateways.csv
@@ -9,9 +9,7 @@ null;FLT_CARRIER;52.8.201.128;0;;;name:Skyetel 3rd Priority Outbound Call,gwgrou
 null;FLT_CARRIER;50.17.48.216;0;;;name:Skyetel 4rd Priority Outbound Call,gwgroup:2,addr_id:26
 null;FLT_CARRIER;52.32.223.28;0;;;name:Skyetel North West High Cost Outbound Traffic,gwgroup:2,addr_id:27
 null;FLT_CARRIER;52.4.178.107;0;;;name:Skyetel South East High Cost Outbound Traffic,gwgroup:2,addr_id:28
-null;FLT_CARRIER;147.75.60.160;0;;;name:Flowroute US-West-WA,gwgroup:3,addr_id:29
 null;FLT_CARRIER;34.210.91.112;0;;;name:Flowroute US-West-OR,gwgroup:3,addr_id:30
-null;FLT_CARRIER;147.75.65.192;0;;;name:Flowroute US-East-NJ,gwgroup:3,addr_id:31
 null;FLT_CARRIER;34.226.36.32;0;;;name:Flowroute US-East-VA,gwgroup:3,addr_id:32
 null;FLT_CARRIER;81.201.82.45;0;;;name:Voxbone Belgium,gwgroup:4,addr_id:33
 null;FLT_CARRIER;81.201.84.195;0;;;name:Voxbone LA,gwgroup:4,addr_id:34

--- a/kamailio/defaults/dr_gw_lists.csv
+++ b/kamailio/defaults/dr_gw_lists.csv
@@ -1,6 +1,6 @@
 null;45,46,47,48,49,50,51;name:Twilio NA Inbound CarrierGroup,type:8
 null;1,2,3,4,5,6,7,8,9,10,11;name:Skyetel CarrierGroup,type:8
-null;12,13,14,15;name:Flowroute CarrierGroup,type:8
+null;13,15;name:Flowroute CarrierGroup,type:8
 null;16,17,18,19,20,21;name:Voxbone CarrierGroup,type:8
 null;22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37;name:VoIP Innovations Inbound IP's CarrierGroup,type:8
 null;39,40,41;name:VoIP Innovations Outbound Conversational IP's CarrierGroup,type:8


### PR DESCRIPTION
Flowroute pops have changed in recent times. The removal of the WA location for almost a year now, and NJ is being actively removed currently. 

More details can be found on their blog [https://support.flowroute.com/823997-Service-Impacting-Updates-to-Flowroute-Edge-Proxy-NJ-HK-AMS-PoPs-in-2022](https://support.flowroute.com/823997-Service-Impacting-Updates-to-Flowroute-Edge-Proxy-NJ-HK-AMS-PoPs-in-2022)

