### PR TITLE
Added dependency to support properly building RTPEngine on Debian 10

### DIFF
--- a/rtpengine/debian/install.sh
+++ b/rtpengine/debian/install.sh
@@ -28,6 +28,7 @@ function install {
     apt-get install -y default-libmysqlclient-dev
     apt-get install -y module-assistant
     apt-get install -y dkms
+    apt-get install -y cmake
     apt-get install -y unzip
     apt-get install -y libavresample-dev
     apt-get install -y linux-headers-$(uname -r)
@@ -47,7 +48,7 @@ function install {
     if [[ "$CODENAME" == "bullseye" ]]; then
 	apt-get install -y -t bullseye libiptc-dev libxtables-dev
 	apt-get install -y -t bullseye libjson-perl libmosquitto-dev python3-websockets
-	apt-get install -y libbcg729-0  libbcg729-dev
+	apt-get install -y libbcg729-0  libbcg729-dev libavcodec-extra
 	# Over-ride version of RTPEngine
 	RTPENGINE_VER=mr10.4.1.1
         printdbg "Overriding RTPEngine Version to ${RTPENGINE_VER}"


### PR DESCRIPTION
Debian 10 can not build and install RTPengine due to missing dependencies (cmake bcg729-dev)
Added cmake and libavcodec-extra to dependency libavcodec-extra is recommended to be installed on rtpengine github under debian to support additional codecs.

This now complies correctly using:
*  `disprouter.sh install -rtp`
* `dsiprouter.sh install -all -servernat`