### PR TITLE
Updated RTPEngine dependency

### DIFF
--- a/rtpengine/debian/install.sh
+++ b/rtpengine/debian/install.sh
@@ -28,6 +28,7 @@ function install {
     apt-get install -y default-libmysqlclient-dev
     apt-get install -y module-assistant
     apt-get install -y dkms
+    apt-get install -y cmake
     apt-get install -y unzip
     apt-get install -y libavresample-dev
     apt-get install -y linux-headers-$(uname -r)
@@ -47,7 +48,7 @@ function install {
     if [[ "$CODENAME" == "bullseye" ]]; then
 	apt-get install -y -t bullseye libiptc-dev libxtables-dev
 	apt-get install -y -t bullseye libjson-perl libmosquitto-dev python3-websockets
-	apt-get install -y libbcg729-0  libbcg729-dev
+	apt-get install -y libbcg729-0  libbcg729-dev libavcodec-extra
 	# Over-ride version of RTPEngine
 	RTPENGINE_VER=mr10.4.1.1
         printdbg "Overriding RTPEngine Version to ${RTPENGINE_VER}"

--- a/rtpengine/debian/install.sh
+++ b/rtpengine/debian/install.sh
@@ -22,7 +22,8 @@ function install {
     apt-get install -y libhiredis-dev
     apt-get install -y libjson-glib-dev libpcap0.8-dev libpcap-dev libssl-dev
     apt-get install -y libavfilter-dev
-    apt-get install -y libavformat-dev
+    apt-get install -y libavformat-dev 
+    apt-get isntall -y libavcodec-extra
     apt-get install -y libmysqlclient-dev
     apt-get install -y libmariadbclient-dev
     apt-get install -y default-libmysqlclient-dev
@@ -48,7 +49,7 @@ function install {
     if [[ "$CODENAME" == "bullseye" ]]; then
 	apt-get install -y -t bullseye libiptc-dev libxtables-dev
 	apt-get install -y -t bullseye libjson-perl libmosquitto-dev python3-websockets
-	apt-get install -y libbcg729-0  libbcg729-dev libavcodec-extra
+	apt-get install -y libbcg729-0  libbcg729-dev
 	# Over-ride version of RTPEngine
 	RTPENGINE_VER=mr10.4.1.1
         printdbg "Overriding RTPEngine Version to ${RTPENGINE_VER}"


### PR DESCRIPTION
Updated RTPEngine build dependency to include cmake and libavcodec-extra
Allows to successful building of RTPengine on Debain. 

libavcodec-extra - is recommended by RTPEngine for installation on debain to support additional codecs. 
_Userfule if you want to convert from formats like opus to ulaw_