### PR TITLE
v0.71 bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 [//]: # (END_SECTION HEADER)
 [//]: # (START_SECTION COMMITS
-55999c50bc20618f66ce373a78fd0d138965ea3e
+f479b3139e108d9222232ee56314c2b91dcbad26
+3b02dc02eeaee8d4e8ca13741489c2e6f72de230
 a787ec5760bf147c755950116a9e440d181a2e9d
 35b4d7233eeda44587c59f0593f5599f82898f65
 1fc9ae71deb1b5191c68a3171bf9b5269e198b80
@@ -2082,10 +2083,26 @@ a72121b9551921aa3dced32d943c6034ba318f82
 ce6c5aac0db5476dc496c34388e4f9ce2c4b86e5
 b46b1e64f06f448bde78b98e3ae8228ce5f96067
 END_SECTION COMMITS)
-[//]: # (START_SECTION 55999c50bc20618f66ce373a78fd0d138965ea3e)
+[//]: # (START_SECTION f479b3139e108d9222232ee56314c2b91dcbad26)
+### Fix Missing Kamailio Config Subst
+
+> Commit: [f479b3139e108d9222232ee56314c2b91dcbad26](https://github.com/dOpensource/dsiprouter/commit/f479b3139e108d9222232ee56314c2b91dcbad26)  
+> Date: Sat, 10 Dec 2022 13:17:06 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- add missing subst defines to kamailio config
+
+
+---
+
+[//]: # (END_SECTION f479b3139e108d9222232ee56314c2b91dcbad26)
+[//]: # (START_SECTION 3b02dc02eeaee8d4e8ca13741489c2e6f72de230)
 ### Increase CDR Field Sizes
 
-> Commit: [55999c50bc20618f66ce373a78fd0d138965ea3e](https://github.com/dOpensource/dsiprouter/commit/55999c50bc20618f66ce373a78fd0d138965ea3e)  
+> Commit: [3b02dc02eeaee8d4e8ca13741489c2e6f72de230](https://github.com/dOpensource/dsiprouter/commit/3b02dc02eeaee8d4e8ca13741489c2e6f72de230)  
 > Date: Sat, 10 Dec 2022 13:12:31 -0500  
 > Author: Tyler Moore (tmoore@goflyball.com)  
 > Committer: Tyler Moore (tmoore@goflyball.com)  
@@ -2098,7 +2115,7 @@ END_SECTION COMMITS)
 
 ---
 
-[//]: # (END_SECTION 55999c50bc20618f66ce373a78fd0d138965ea3e)
+[//]: # (END_SECTION 3b02dc02eeaee8d4e8ca13741489c2e6f72de230)
 [//]: # (START_SECTION a787ec5760bf147c755950116a9e440d181a2e9d)
 ### Removed Rabbit MQ logic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@
 
 [//]: # (END_SECTION HEADER)
 [//]: # (START_SECTION COMMITS
-261eee311b7dd3e777728999a310ad1cc4bb12c7
+55999c50bc20618f66ce373a78fd0d138965ea3e
+a787ec5760bf147c755950116a9e440d181a2e9d
+35b4d7233eeda44587c59f0593f5599f82898f65
+1fc9ae71deb1b5191c68a3171bf9b5269e198b80
+200cd34e29349b99b6da38065cee4102e916d98c
+cf5c5200f68b97d88ad2dec4331d04db3e189a51
+ee072c3650e9a008900cf00132804e83af3fbf56
+90affe1dbac937b1fd09e2d5ba90ae07491948e6
+0a4cf6a2b0a8352659dfd8145692ed6147ba3694
+b26b91e04a541685d0d5a78277c4ab7bf564669d
+f321abf3809cc8b6696be3b6423a073a76f81365
+84bd75cd3f05b01b765ad8be4d4a096681ac681d
+4452960d95d0bf8e6c9e9c8d60b51b376f6551d9
+3341101669b42a7341643d13c284f696da4a0caf
+f53bfa21e447f53f22ff20a2a64b7b859835e8e6
+591aeeb225c1f542bb49a078d6353a7083ee8fc5
+c1e0be12cf158786064bc1f1d1c4bdf3db2159f3
 b3a9b851f5b0c095eede8d5913f102b4f62b04f0
 cdd8aac9f751a212fcca7f01e7a5159d6ab749f2
 a1cba27cee11cd0de0a46ebec89c65eeb86a302a
@@ -53,7 +69,9 @@ c028ac3999a88df3c2c62a342e1918f31ea9f0b8
 e61d6d6e9ff125381d4813a5db0782eff5066e66
 466bdfbc9a916580d2e70950af6fb54ef4cf8bb5
 b5e8df8a4d4b82994d6be2b6a0dbbd26dcb34e5a
+431f37ffd6cb1daba38e2a6f654da35dbd81c3a2
 d50f15b4c4eb65069dbaae31e3bc5b86075bd57f
+56c39e111ed66326b50447bb6ed12826e5cd74cd
 96221e574830aea41cfc23c9237cbc6a336a8e95
 ccea19047f2b1959fe0bbc0e6cf70a66576e5d15
 1e029d26dcbbc3ce204cfe49d25502d1ec23355c
@@ -93,6 +111,11 @@ c40702e443e6c3fece31cc66338d051527067d88
 34e30b6dc3e50e80f8cfa229416d4c409fc49832
 2a362b9331c4ee2e7b5473712ca54d98643586b2
 3ce7eca6f9e31f5351260e085a4e720ede16d066
+1ba6465cfffd6c80d1e0f07314cda1eee1dd25ed
+6a9f9b2de498ad93c7d84e92f7be8c43d7fb146b
+bc32b97a11ff4729a060685a30ae8a019a5491f0
+6fe3c84fec77ae9ec554c2eea18eb74e1982bcff
+2f6b076c27cdb5c324a9ccfeab9960c6b8952ab7
 e9f3dd7059bd73e4a73ebee4e5eabd7bfaffbdc5
 162e3ed4fdc9e48d0f5e2c061cbb1d44db317735
 34e29bcb6fef9fea67de067928e27aa861ee4063
@@ -2059,10 +2082,260 @@ a72121b9551921aa3dced32d943c6034ba318f82
 ce6c5aac0db5476dc496c34388e4f9ce2c4b86e5
 b46b1e64f06f448bde78b98e3ae8228ce5f96067
 END_SECTION COMMITS)
-[//]: # (START_SECTION 261eee311b7dd3e777728999a310ad1cc4bb12c7)
+[//]: # (START_SECTION 55999c50bc20618f66ce373a78fd0d138965ea3e)
+### Increase CDR Field Sizes
+
+> Commit: [55999c50bc20618f66ce373a78fd0d138965ea3e](https://github.com/dOpensource/dsiprouter/commit/55999c50bc20618f66ce373a78fd0d138965ea3e)  
+> Date: Sat, 10 Dec 2022 13:12:31 -0500  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- Resolves #472
+- increase varchar sizes to handle edge cases
+
+
+---
+
+[//]: # (END_SECTION 55999c50bc20618f66ce373a78fd0d138965ea3e)
+[//]: # (START_SECTION a787ec5760bf147c755950116a9e440d181a2e9d)
+### Removed Rabbit MQ logic
+
+> Commit: [a787ec5760bf147c755950116a9e440d181a2e9d](https://github.com/dOpensource/dsiprouter/commit/a787ec5760bf147c755950116a9e440d181a2e9d)  
+> Date: Sun, 4 Dec 2022 22:37:46 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION a787ec5760bf147c755950116a9e440d181a2e9d)
+[//]: # (START_SECTION 35b4d7233eeda44587c59f0593f5599f82898f65)
+### Added support for spinning up a demo server
+
+> Commit: [35b4d7233eeda44587c59f0593f5599f82898f65](https://github.com/dOpensource/dsiprouter/commit/35b4d7233eeda44587c59f0593f5599f82898f65)  
+> Date: Sun, 4 Dec 2022 22:33:35 -0500  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 35b4d7233eeda44587c59f0593f5599f82898f65)
+[//]: # (START_SECTION 1fc9ae71deb1b5191c68a3171bf9b5269e198b80)
+### Added push notification updates
+
+> Commit: [1fc9ae71deb1b5191c68a3171bf9b5269e198b80](https://github.com/dOpensource/dsiprouter/commit/1fc9ae71deb1b5191c68a3171bf9b5269e198b80)  
+> Date: Wed, 30 Nov 2022 09:34:52 -0600  
+> Author: Maurice Rogers (cruzer45@gmail.com)  
+> Committer: Maurice Rogers (cruzer45@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 1fc9ae71deb1b5191c68a3171bf9b5269e198b80)
+[//]: # (START_SECTION 200cd34e29349b99b6da38065cee4102e916d98c)
+### Terraform - Added support for adding a hostname record to DNS
+
+> Commit: [200cd34e29349b99b6da38065cee4102e916d98c](https://github.com/dOpensource/dsiprouter/commit/200cd34e29349b99b6da38065cee4102e916d98c)  
+> Date: Fri, 18 Nov 2022 12:03:37 -0600  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 200cd34e29349b99b6da38065cee4102e916d98c)
+[//]: # (START_SECTION cf5c5200f68b97d88ad2dec4331d04db3e189a51)
+### Updated getInternalCIDR with support for DMZ
+
+> Commit: [cf5c5200f68b97d88ad2dec4331d04db3e189a51](https://github.com/dOpensource/dsiprouter/commit/cf5c5200f68b97d88ad2dec4331d04db3e189a51)  
+> Date: Wed, 2 Nov 2022 00:02:26 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION cf5c5200f68b97d88ad2dec4331d04db3e189a51)
+[//]: # (START_SECTION ee072c3650e9a008900cf00132804e83af3fbf56)
+### Fixed issues with install scripts
+
+> Commit: [ee072c3650e9a008900cf00132804e83af3fbf56](https://github.com/dOpensource/dsiprouter/commit/ee072c3650e9a008900cf00132804e83af3fbf56)  
+> Date: Tue, 1 Nov 2022 02:28:48 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION ee072c3650e9a008900cf00132804e83af3fbf56)
+[//]: # (START_SECTION 90affe1dbac937b1fd09e2d5ba90ae07491948e6)
+### Fixed issues with install scripts
+
+> Commit: [90affe1dbac937b1fd09e2d5ba90ae07491948e6](https://github.com/dOpensource/dsiprouter/commit/90affe1dbac937b1fd09e2d5ba90ae07491948e6)  
+> Date: Tue, 1 Nov 2022 02:27:26 +0000  
+> Author: root (root@mack-dsip-v0.710)  
+> Committer: root (root@mack-dsip-v0.710)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 90affe1dbac937b1fd09e2d5ba90ae07491948e6)
+[//]: # (START_SECTION 0a4cf6a2b0a8352659dfd8145692ed6147ba3694)
+### Fixed issue with Kamailio.cfg
+
+> Commit: [0a4cf6a2b0a8352659dfd8145692ed6147ba3694](https://github.com/dOpensource/dsiprouter/commit/0a4cf6a2b0a8352659dfd8145692ed6147ba3694)  
+> Date: Mon, 31 Oct 2022 23:30:26 +0000  
+> Author: root (root@mack-dsip-v0.710)  
+> Committer: root (root@mack-dsip-v0.710)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 0a4cf6a2b0a8352659dfd8145692ed6147ba3694)
+[//]: # (START_SECTION b26b91e04a541685d0d5a78277c4ab7bf564669d)
+### Added DMZ Support
+
+> Commit: [b26b91e04a541685d0d5a78277c4ab7bf564669d](https://github.com/dOpensource/dsiprouter/commit/b26b91e04a541685d0d5a78277c4ab7bf564669d)  
+> Date: Mon, 31 Oct 2022 23:03:33 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION b26b91e04a541685d0d5a78277c4ab7bf564669d)
+[//]: # (START_SECTION f321abf3809cc8b6696be3b6423a073a76f81365)
+### Updated Pass-Thru Authentication - Added support to handle pass-thru when the hostname of the media server is used as the endpoint.
+
+> Commit: [f321abf3809cc8b6696be3b6423a073a76f81365](https://github.com/dOpensource/dsiprouter/commit/f321abf3809cc8b6696be3b6423a073a76f81365)  
+> Date: Tue, 18 Oct 2022 10:38:56 +0000  
+> Author: Mack (mack@dopensource.com)  
+> Committer: Mack (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION f321abf3809cc8b6696be3b6423a073a76f81365)
+[//]: # (START_SECTION 84bd75cd3f05b01b765ad8be4d4a096681ac681d)
+### Fixed issue with ACK on Domain Routing: - Changed VALIDATE_ROUTE_HEADERS to CUSTOM_WITHINDLG - Changed logic to not remove the first Route header - this causes loose_route to functionaly incorrectly
+
+> Commit: [84bd75cd3f05b01b765ad8be4d4a096681ac681d](https://github.com/dOpensource/dsiprouter/commit/84bd75cd3f05b01b765ad8be4d4a096681ac681d)  
+> Date: Tue, 11 Oct 2022 04:06:58 +0000  
+> Author: root (root@dsiptest.dsiprouter.net)  
+> Committer: root (root@dsiptest.dsiprouter.net)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 84bd75cd3f05b01b765ad8be4d4a096681ac681d)
+[//]: # (START_SECTION 4452960d95d0bf8e6c9e9c8d60b51b376f6551d9)
+### Added a sleep after the update to give apt time to release the locks
+
+> Commit: [4452960d95d0bf8e6c9e9c8d60b51b376f6551d9](https://github.com/dOpensource/dsiprouter/commit/4452960d95d0bf8e6c9e9c8d60b51b376f6551d9)  
+> Date: Tue, 4 Oct 2022 08:02:09 -0600  
+> Author: Maurice Rogers (cruzer45@gmail.com)  
+> Committer: Maurice Rogers (cruzer45@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 4452960d95d0bf8e6c9e9c8d60b51b376f6551d9)
+[//]: # (START_SECTION 3341101669b42a7341643d13c284f696da4a0caf)
+### updated the install files to create the directory for serving up manual certificates
+
+> Commit: [3341101669b42a7341643d13c284f696da4a0caf](https://github.com/dOpensource/dsiprouter/commit/3341101669b42a7341643d13c284f696da4a0caf)  
+> Date: Tue, 4 Oct 2022 07:26:45 -0600  
+> Author: Maurice Rogers (cruzer45@gmail.com)  
+> Committer: Maurice Rogers (cruzer45@gmail.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 3341101669b42a7341643d13c284f696da4a0caf)
+[//]: # (START_SECTION f53bfa21e447f53f22ff20a2a64b7b859835e8e6)
+### Fix Failover Routing
+
+> Commit: [f53bfa21e447f53f22ff20a2a64b7b859835e8e6](https://github.com/dOpensource/dsiprouter/commit/f53bfa21e447f53f22ff20a2a64b7b859835e8e6)  
+> Date: Fri, 30 Sep 2022 10:49:17 -0400  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+- change sort algorithm for drouting
+- fix call limit out of scope error
+- fix failover routing on no reply
+- fix failover routing on dropped packets
+- update failover timeouts to be more realistic
+- fix route header variable out of scope error
+- make debugger more readable in debug mode
+- fix usrloc variable typo
+
+
+---
+
+[//]: # (END_SECTION f53bfa21e447f53f22ff20a2a64b7b859835e8e6)
+[//]: # (START_SECTION 591aeeb225c1f542bb49a078d6353a7083ee8fc5)
+### FusionPBX Sync Fixes: - Added logic to exclude the default FusionPBX domain from being added during sync's.  This fixes an ACK loop - Deprecated logic for using the Docker instance of Nginx
+
+> Commit: [591aeeb225c1f542bb49a078d6353a7083ee8fc5](https://github.com/dOpensource/dsiprouter/commit/591aeeb225c1f542bb49a078d6353a7083ee8fc5)  
+> Date: Fri, 30 Sep 2022 11:03:48 +0000  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: Mack Hendricks (mack@dopensource.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 591aeeb225c1f542bb49a078d6353a7083ee8fc5)
+[//]: # (START_SECTION c1e0be12cf158786064bc1f1d1c4bdf3db2159f3)
 ### Installation Bug Fixes
 
-> Commit: [261eee311b7dd3e777728999a310ad1cc4bb12c7](https://github.com/dOpensource/dsiprouter/commit/261eee311b7dd3e777728999a310ad1cc4bb12c7)  
+> Commit: [c1e0be12cf158786064bc1f1d1c4bdf3db2159f3](https://github.com/dOpensource/dsiprouter/commit/c1e0be12cf158786064bc1f1d1c4bdf3db2159f3)  
 > Date: Thu, 29 Sep 2022 09:37:20 -0400  
 > Author: Tyler Moore (tmoore@goflyball.com)  
 > Committer: Tyler Moore (tmoore@goflyball.com)  
@@ -2076,7 +2349,7 @@ END_SECTION COMMITS)
 
 ---
 
-[//]: # (END_SECTION 261eee311b7dd3e777728999a310ad1cc4bb12c7)
+[//]: # (END_SECTION c1e0be12cf158786064bc1f1d1c4bdf3db2159f3)
 [//]: # (START_SECTION b3a9b851f5b0c095eede8d5913f102b4f62b04f0)
 ### Installation Bug Fixes
 
@@ -2870,6 +3143,21 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION b5e8df8a4d4b82994d6be2b6a0dbbd26dcb34e5a)
+[//]: # (START_SECTION 431f37ffd6cb1daba38e2a6f654da35dbd81c3a2)
+### Fix Ordering of Default Carriers
+
+> Commit: [431f37ffd6cb1daba38e2a6f654da35dbd81c3a2](https://github.com/dOpensource/dsiprouter/commit/431f37ffd6cb1daba38e2a6f654da35dbd81c3a2)  
+> Date: Thu, 11 Aug 2022 13:37:14 -0400  
+> Author: Tyler Moore (tmoore@goflyball.com)  
+> Committer: Tyler Moore (tmoore@goflyball.com)  
+> Signed: Tyler Moore (devopsec) <tmoore@goflyball.com>  
+
+
+
+
+---
+
+[//]: # (END_SECTION 431f37ffd6cb1daba38e2a6f654da35dbd81c3a2)
 [//]: # (START_SECTION d50f15b4c4eb65069dbaae31e3bc5b86075bd57f)
 ### Fix pre-commit and requirements.txt
 
@@ -2885,6 +3173,21 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION d50f15b4c4eb65069dbaae31e3bc5b86075bd57f)
+[//]: # (START_SECTION 56c39e111ed66326b50447bb6ed12826e5cd74cd)
+### Update pre-commit
+
+> Commit: [56c39e111ed66326b50447bb6ed12826e5cd74cd](https://github.com/dOpensource/dsiprouter/commit/56c39e111ed66326b50447bb6ed12826e5cd74cd)  
+> Date: Mon, 8 Aug 2022 22:22:57 -0400  
+> Author: Mack Hendricks (mack@dopensource.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 56c39e111ed66326b50447bb6ed12826e5cd74cd)
 [//]: # (START_SECTION 96221e574830aea41cfc23c9237cbc6a336a8e95)
 ### Bug Fixes for Updated OS Support
 
@@ -3523,6 +3826,81 @@ END_SECTION COMMITS)
 ---
 
 [//]: # (END_SECTION 3ce7eca6f9e31f5351260e085a4e720ede16d066)
+[//]: # (START_SECTION 1ba6465cfffd6c80d1e0f07314cda1eee1dd25ed)
+### Added clarity to debian10 set-hostname
+
+> Commit: [1ba6465cfffd6c80d1e0f07314cda1eee1dd25ed](https://github.com/dOpensource/dsiprouter/commit/1ba6465cfffd6c80d1e0f07314cda1eee1dd25ed)  
+> Date: Wed, 27 Apr 2022 23:43:52 -0700  
+> Author: VOICE1 (voice1me@gmail.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 1ba6465cfffd6c80d1e0f07314cda1eee1dd25ed)
+[//]: # (START_SECTION 6a9f9b2de498ad93c7d84e92f7be8c43d7fb146b)
+### Added additional details to outbound routes.
+
+> Commit: [6a9f9b2de498ad93c7d84e92f7be8c43d7fb146b](https://github.com/dOpensource/dsiprouter/commit/6a9f9b2de498ad93c7d84e92f7be8c43d7fb146b)  
+> Date: Wed, 27 Apr 2022 23:20:50 -0700  
+> Author: VOICE1 (voice1me@gmail.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 6a9f9b2de498ad93c7d84e92f7be8c43d7fb146b)
+[//]: # (START_SECTION bc32b97a11ff4729a060685a30ae8a019a5491f0)
+### Removed EOL Pops from Flowroute
+
+> Commit: [bc32b97a11ff4729a060685a30ae8a019a5491f0](https://github.com/dOpensource/dsiprouter/commit/bc32b97a11ff4729a060685a30ae8a019a5491f0)  
+> Date: Mon, 25 Apr 2022 16:27:47 -0700  
+> Author: VOICE1 (voice1me@gmail.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION bc32b97a11ff4729a060685a30ae8a019a5491f0)
+[//]: # (START_SECTION 6fe3c84fec77ae9ec554c2eea18eb74e1982bcff)
+### Removed EOL PoPs from Flowroute
+
+> Commit: [6fe3c84fec77ae9ec554c2eea18eb74e1982bcff](https://github.com/dOpensource/dsiprouter/commit/6fe3c84fec77ae9ec554c2eea18eb74e1982bcff)  
+> Date: Mon, 25 Apr 2022 16:27:12 -0700  
+> Author: VOICE1 (voice1me@gmail.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 6fe3c84fec77ae9ec554c2eea18eb74e1982bcff)
+[//]: # (START_SECTION 2f6b076c27cdb5c324a9ccfeab9960c6b8952ab7)
+### Removed EOL PoPs from Flowroute
+
+> Commit: [2f6b076c27cdb5c324a9ccfeab9960c6b8952ab7](https://github.com/dOpensource/dsiprouter/commit/2f6b076c27cdb5c324a9ccfeab9960c6b8952ab7)  
+> Date: Mon, 25 Apr 2022 16:26:22 -0700  
+> Author: VOICE1 (voice1me@gmail.com)  
+> Committer: GitHub (noreply@github.com)  
+> Signed:   
+
+
+
+
+---
+
+[//]: # (END_SECTION 2f6b076c27cdb5c324a9ccfeab9960c6b8952ab7)
 [//]: # (START_SECTION e9f3dd7059bd73e4a73ebee4e5eabd7bfaffbdc5)
 ### Added our v2 License Manager - Initial commit
 

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -49,7 +49,7 @@
 #exec 19> >(awk -v time=$(date +"[%Y-%m-%d_%H:%M:%S] ") '{ print time, $0; fflush(); }' > /tmp/debug/trace.log)
 #
 #BASH_XTRACEFD="19"
-set -x
+#set -x
 #===========================================================#
 
 

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -145,10 +145,13 @@ function setDynamicScriptSettings() {
             printerr "IPV6 enabled but address [$INTERNAL_IP6] is not routable"
             cleanupAndExit 1
         fi
-        export IPV6_ENABLED=1
+        export IPV6_ENABLED=0
     else
         export IPV6_ENABLED=0
     fi
+
+    # Determine if DMZ was enabled
+    export DMZ_ENABLED=${DMZ_ENABLED:-$(getConfigAttrib 'DMZ_ENABLED' ${DSIP_CONFIG_FILE})}
 
     # grab the ipv4 network and domain settings dynamically
     export INTERNAL_IP=$(getInternalIP -4)
@@ -819,7 +822,7 @@ function updateRtpengineConfig() {
         fi
     fi
     if (( ${DMZ_ENABLED} == 1 )); then
-        INTERFACE="public/${EXTERNAL_IP};private/${IXTERNAL_IP}"
+        INTERFACE="public/${EXTERNAL_IP};private/${INTERNAL_IP}"
     else
         INTERFACE="ipv4/${INTERNAL_IP}"
     fi
@@ -3197,6 +3200,7 @@ function processCMD() {
 			PUBLIC_INTERFACE=$(echo "$TMP" | cut -d ',' -f 1)
 			PRIVATE_INTERFACE=$(echo "$TMP" | cut -d ',' -f 2)
 			export INTERNAL_IP=$(getIP -4 "$PRIVATE_INTERFACE")
+			export INTERNAL_IP_NET=$(getInternalCIDR -4 "$INTERNAL_IP")
 			export EXTERNAL_IP=$(getIP -4 "$PUBLIC_INTERFACE")
 			DMZ_ENABLED=1
                         setConfigAttrib 'DMZ_ENABLED' "True" ${DSIP_CONFIG_FILE}

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -699,8 +699,8 @@ function updateKamailioConfig() {
     else
         disableKamailioConfigAttrib 'WITH_HOMER' ${DSIP_KAMAILIO_CONFIG_FILE}
     fi
-    #setKamailioConfigSubst 'DSIP_ID' "${DSIP_ID}" ${DSIP_KAMAILIO_CONFIG_FILE}
-    #setKamailioConfigSubst 'DSIP_CLUSTER_ID' "${DSIP_CLUSTER_ID}" ${DSIP_KAMAILIO_CONFIG_FILE}
+    setKamailioConfigSubst 'DSIP_ID' "${DSIP_ID}" ${DSIP_KAMAILIO_CONFIG_FILE}
+    setKamailioConfigSubst 'DSIP_CLUSTER_ID' "${DSIP_CLUSTER_ID}" ${DSIP_KAMAILIO_CONFIG_FILE}
     setKamailioConfigSubst 'DSIP_VERSION' "${DSIP_VERSION}" ${DSIP_KAMAILIO_CONFIG_FILE}
     setKamailioConfigSubst 'INTERNAL_IP_ADDR' "${INTERNAL_IP}" ${DSIP_KAMAILIO_CONFIG_FILE}
     setKamailioConfigSubst 'INTERNAL_IP6_ADDR' "${INTERNAL_IP6}" ${DSIP_KAMAILIO_CONFIG_FILE}

--- a/dsiprouter/dsip_lib.sh
+++ b/dsiprouter/dsip_lib.sh
@@ -448,6 +448,12 @@ function getInternalIP() {
             local IPV6_ENABLED=${IPV6_ENABLED:-0}
             ;;
     esac
+	    
+    if (( ${IPV6_ENABLED} == 1 )); then
+	INTERFACE=$(ip -br -6 a| grep UP | head -1 | awk {'print $1'})
+    else
+	INTERFACE=$(ip -4 route show default | awk '{print $5}')
+    fi
 
     # Get the ip address without depending on DNS
     if (( ${IPV4_ENABLED} == 1 )); then

--- a/gui/modules/cdr/cdrs.sql
+++ b/gui/modules/cdr/cdrs.sql
@@ -25,18 +25,18 @@ DROP TABLE IF EXISTS `acc`;
 CREATE TABLE `acc` (
   `id`            int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   `method`        varchar(16)      NOT NULL DEFAULT '',
-  `from_tag`      varchar(64)      NOT NULL DEFAULT '',
-  `to_tag`        varchar(64)      NOT NULL DEFAULT '',
-  `callid`        varchar(128)     NOT NULL DEFAULT '',
+  `from_tag`      varchar(128)      NOT NULL DEFAULT '',
+  `to_tag`        varchar(128)      NOT NULL DEFAULT '',
+  `callid`        varchar(255)     NOT NULL DEFAULT '',
   `sip_code`      char(3)          NOT NULL DEFAULT '',
-  `sip_reason`    varchar(32)      NOT NULL DEFAULT '',
-  `time`          datetime         NOT NULL DEFAULT '2000-01-01 00:00:00',
+  `sip_reason`    varchar(255)      NOT NULL DEFAULT '',
+  `time`          datetime         NOT NULL DEFAULT NOW(),
   `src_ip`        varchar(64)      NOT NULL DEFAULT '',
-  `dst_ouser`     varchar(64)      NOT NULL DEFAULT '',
-  `dst_user`      varchar(64)      NOT NULL DEFAULT '',
-  `dst_domain`    varchar(128)     NOT NULL DEFAULT '',
-  `src_user`      varchar(64)      NOT NULL DEFAULT '',
-  `src_domain`    varchar(128)     NOT NULL DEFAULT '',
+  `dst_ouser`     varchar(128)      NOT NULL DEFAULT '',
+  `dst_user`      varchar(128)      NOT NULL DEFAULT '',
+  `dst_domain`    varchar(255)     NOT NULL DEFAULT '',
+  `src_user`      varchar(128)      NOT NULL DEFAULT '',
+  `src_domain`    varchar(255)     NOT NULL DEFAULT '',
   `cdr_id`        int(10) UNSIGNED NOT NULL DEFAULT '0',
   `calltype`      varchar(20)               DEFAULT NULL,
   `src_gwgroupid` int(10) UNSIGNED NOT NULL DEFAULT '0',
@@ -54,21 +54,21 @@ DROP TABLE IF EXISTS `cdrs`;
 /*!40101 SET @saved_cs_client = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `cdrs` (
-  `cdr_id`          bigint(20)       NOT NULL AUTO_INCREMENT,
-  `src_username`    varchar(64)      NOT NULL DEFAULT '',
-  `src_domain`      varchar(128)     NOT NULL DEFAULT '',
-  `dst_username`    varchar(64)      NOT NULL DEFAULT '',
-  `dst_domain`      varchar(128)     NOT NULL DEFAULT '',
-  `dst_ousername`   varchar(64)      NOT NULL DEFAULT '',
-  `call_start_time` datetime         NOT NULL DEFAULT '2000-01-01 00:00:00',
+  `cdr_id`          bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `src_username`    varchar(128)      NOT NULL DEFAULT '',
+  `src_domain`      varchar(255)     NOT NULL DEFAULT '',
+  `dst_username`    varchar(128)      NOT NULL DEFAULT '',
+  `dst_domain`      varchar(255)     NOT NULL DEFAULT '',
+  `dst_ousername`   varchar(128)      NOT NULL DEFAULT '',
+  `call_start_time` datetime         NOT NULL,
   `duration`        int(10) UNSIGNED NOT NULL DEFAULT '0',
-  `sip_call_id`     varchar(128)     NOT NULL DEFAULT '',
+  `sip_call_id`     varchar(255)     NOT NULL DEFAULT '',
   `sip_from_tag`    varchar(128)     NOT NULL DEFAULT '',
   `sip_to_tag`      varchar(128)     NOT NULL DEFAULT '',
   `src_ip`          varchar(64)      NOT NULL DEFAULT '',
   `cost`            int(11)          NOT NULL DEFAULT '0',
   `rated`           int(11)          NOT NULL DEFAULT '0',
-  `created`         datetime         NOT NULL,
+  `created`         datetime         NOT NULL DEFAULT NOW(),
   `calltype`        varchar(20)               DEFAULT NULL,
   `fraud`           bool             NOT NULL DEFAULT '0',
   `src_gwgroupid`   int(10) UNSIGNED NOT NULL DEFAULT '0',
@@ -95,7 +95,7 @@ BEGIN
   DECLARE done int DEFAULT 0;
   DECLARE bye_record int DEFAULT 0;
   DECLARE v_src_user,v_src_domain,v_dst_user,v_dst_domain,v_callid,v_from_tag,
-    v_to_tag,v_src_ip,v_calltype varchar(64);
+    v_to_tag,v_src_ip,v_calltype varchar(255);
   DECLARE v_src_gwgroupid, v_dst_gwgroupid int(11);
   DECLARE v_inv_time, v_bye_time datetime;
   DECLARE inv_cursor CURSOR FOR
@@ -171,7 +171,7 @@ BEGIN
   DECLARE done, rate_record, vx_cost int DEFAULT 0;
   DECLARE v_cdr_id bigint DEFAULT 0;
   DECLARE v_duration, v_rate_unit, v_time_unit int DEFAULT 0;
-  DECLARE v_dst_username varchar(64);
+  DECLARE v_dst_username varchar(255);
   DECLARE cdrs_cursor CURSOR FOR SELECT cdr_id, dst_username, duration
                                  FROM cdrs
                                  WHERE rated = 0;

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -38,7 +38,7 @@ DSIP_CERTS_DIR = '/etc/dsiprouter/certs'
 
 # dSIPRouter internal settings
 
-VERSION = '0.70'
+VERSION = '0.71'
 DEBUG = False
 # '' (default)  = handle inbound with domain mapping from endpoints, inbound from carriers and outbound to carriers
 # 'outbound'    = act as an outbound proxy only (no domain routing)

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -103,6 +103,10 @@ FLOWROUTE_API_ROOT_URL = 'https://api.flowroute.com/v2'
 HOMER_HEP_HOST = ''
 HOMER_HEP_PORT = 9060
 
+# DMZ support
+# INTERNAL_IP_ADDR becomes private ip and EXTERNAL_IP_ADDR becomes the public ip
+DMZ_ENABLED = True
+
 # updated dynamically! These values will be overwritten
 IPV6_ENABLED = False
 INTERNAL_IP_ADDR = '192.168.0.1'

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -45,6 +45,8 @@
 # Defined Constants with String Replacement
 #======================================================================
 
+#!substdef "!DSIP_ID!1!g"
+#!substdef "!DSIP_CLUSTER_ID!1!g"
 #!substdef "!DSIP_VERSION!0.70!g"
 #!substdef "!INTERNAL_IP_ADDR!10.118.0.2!g"
 #!substdef "!INTERNAL_IP_NET!10.118.0.0/20!g"
@@ -219,7 +221,7 @@ listen = tcp:INTERNAL_IP_ADDR:SIP_PORT
 #!ifdef WITH_DMZ
 listen = udp:EXTERNAL_IP_ADDR:SIP_PORT
 listen = tcp:EXTERNAL_IP_ADDR:SIP_PORT
-#!endif 
+#!endif
 #!ifdef WITH_WEBSOCKETS
 listen = tls:INTERNAL_IP_ADDR:WSS_PORT
 #!endif
@@ -1447,7 +1449,7 @@ failure_route[TELEBLOCK_FAILURE] {
 
 # Wrapper for relaying requests
 route[RELAY] {
-	
+
 	# DMZ direction detection
 	route(DMZ_DIR_DETECT);
 
@@ -1907,7 +1909,7 @@ route[REGISTRAR] {
 			#Add the Path header for SIP UAC's - so that we know how to route back
 			add_path_received($fU);
 		}
- 
+
 		# Store the pbx ip to domain mapping so that SIP messages from the PBX can be rewritten
                 if !is_ip($(avp(domain_pbx_ip){s.select,0,:})) {
                         if(dns_query($(avp(domain_pbx_ip){s.select,0,:}),"xyz"))
@@ -1942,7 +1944,7 @@ route[REGISTRAR] {
 
 		xlog("L_INFO", "[REGISTER] [PUSH] about to un-suspend transaction rm=$rm ru=$ru tU=$tU td=$td \n");
   		route(JOIN);
-	} 
+	}
 #!endif
 
 	#    #Forward the registration onto one of the servers in the cluster
@@ -2130,7 +2132,7 @@ route[SUSPEND] {
 	t_set_fr(30000);
 
 	if(!t_suspend())
-	{  
+	{
 		xlog("[SUSPEND] [PUSH] failed suspending trasaction [$T(id_index):$T(id_label)]\n");
 		send_reply("501", "Unknown destination");
 		exit;
@@ -2146,10 +2148,10 @@ route[SUSPEND] {
 route[SENDPUSH] {
 	xlog("L_INFO", "  In the [PUSH] route[SENDPUSH] logic.");
 
-        xlog("L_INFO", "[SENDPUSH] Sending teh push notofication.");  
+        xlog("L_INFO", "[SENDPUSH] Sending teh push notofication.");
 
 	#rabbitmq_publish("kamailio", "routing_key", "application/json", "$avp(json_request)");
-	
+
 
 
 	#$var(luaret) = 0;
@@ -2165,7 +2167,7 @@ route[JOIN] {
  	xlog("L_INFO", "  In the [PUSH] route[JOIN] logic.");
 	$var(index)=(int) $(sht(push=>join::$tU@$td){s.select,0,:});
 	$var(label)=(int) $(sht(push=>join::$tU@$td){s.select,1,:});
-	xlog("L_INFO", "[JOIN] [PUSH] suspend $var(index) $var(label)"); 
+	xlog("L_INFO", "[JOIN] [PUSH] suspend $var(index) $var(label)");
 	t_set_fr(30000);
 	t_continue("$var(index)", "$var(label)", "RESUME");
 
@@ -2180,7 +2182,7 @@ route[RESUME] {
 	if !(lookup("location","sip:$rU@$rd"))
 	{
 		switch ($retcode) {
-			case 1: 
+			case 1:
 				xlog("L_INFO","[RESUME] suspend **found** rm=$rm ru=$rU rd=$rd du=$du \n");
 			case -1:
 			case -3:
@@ -2720,7 +2722,7 @@ route[RTPENGINEOFFER] {
 	else if (!isflagset(FLT_SRC_INTERNAL_IP) && isflagset(FLT_DST_INTERNAL_IP)) {
 		$var(reflags)= $var(reflags) + " direction=public direction=private";
 	}
-#!endif 
+#!endif
 
 #!ifdef WITH_IPV6
 	# select interface within rtpengine based on IP versions (by default will use the IPv4 interface)

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -2444,6 +2444,8 @@ route[DMZ_DIR_DETECT] {
 		}
 	}
 #!endif
+
+	return;
 }
 
 # TODO: SERVERNAT for ipv4/ipv6 is detected during startup now, refactor this and dependent flags/logic accordingly

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -32,6 +32,7 @@
 #!define WITH_STIRSHAKEN
 ##!define WITH_IPV6
 ##!define WITH_HOMER
+##!define WITH_DMZ
 
 #======================================================================
 # Define String Replacements Within Config
@@ -44,14 +45,14 @@
 #======================================================================
 
 #!substdef "!DSIP_VERSION!0.70!g"
-#!substdef "!INTERNAL_IP_ADDR!192.168.0.1!g"
-#!substdef "!INTERNAL_IP_NET!192.186.0.1/24!g"
-#!substdef "!INTERNAL_IP6_ADDR!2604:a880:400:d0::2048:3001!g"
-#!substdef "!INTERNAL_IP6_NET!2604:a880:400:d0::2048:3001/64!g"
-#!substdef "!INTERNAL_FQDN!!g"
-#!substdef "!EXTERNAL_IP_ADDR!1.1.1.1!g"
-#!substdef "!EXTERNAL_IP6_ADDR!2604:a880:400:d0::2048:3001!g"
-#!substdef "!EXTERNAL_FQDN!!g"
+#!substdef "!INTERNAL_IP_ADDR!10.118.0.2!g"
+#!substdef "!INTERNAL_IP_NET!10.118.0.0/20!g"
+#!substdef "!INTERNAL_IP6_ADDR!!g"
+#!substdef "!INTERNAL_IP6_NET!!g"
+#!substdef "!INTERNAL_FQDN!multihome!g"
+#!substdef "!EXTERNAL_IP_ADDR!134.122.43.159!g"
+#!substdef "!EXTERNAL_IP6_ADDR!!g"
+#!substdef "!EXTERNAL_FQDN!multihome!g"
 #!substdef "!INBOUND_NLB_FQDN!!g"
 #!substdef "!OUTBOUND_NLB_FQDN!!g"
 #!substdef "!HOMER_HOST!!g"
@@ -69,12 +70,12 @@
 #!ifdef WITH_MYSQL
 #!ifdef WITH_DBCLUSTER
 #!define DBURL "cluster://dbcluster"
-#!define SQLCONN_KAM "kam=>mysql://kamailio:kamailiorw@localhost:3306/kamailio"
-#!define SQLCONN_AST "asterisk=>mysql://kamailio:kamailiorw@localhost:3306/kamailio"
+#!define SQLCONN_KAM "kam=>mysql://kamailio:63X9IONf3ab8FIhZUAREVN2TQ0Tx4XzM1NN9wzTipyZPJoC3TngrT4ZOLS6ABYK2@localhost:3306/kamailio"
+#!define SQLCONN_AST "asterisk=>mysql://kamailio:63X9IONf3ab8FIhZUAREVN2TQ0Tx4XzM1NN9wzTipyZPJoC3TngrT4ZOLS6ABYK2@localhost:3306/kamailio"
 #!else
-#!define DBURL "mysql://kamailio:kamailiorw@localhost:3306/kamailio"
-#!define SQLCONN_KAM "kam=>mysql://kamailio:kamailiorw@localhost:3306/kamailio"
-#!define SQLCONN_AST "asterisk=>mysql://kamailio:kamailiorw@localhost:3306/kamailio"
+#!define DBURL "mysql://kamailio:63X9IONf3ab8FIhZUAREVN2TQ0Tx4XzM1NN9wzTipyZPJoC3TngrT4ZOLS6ABYK2@localhost:3306/kamailio"
+#!define SQLCONN_KAM "kam=>mysql://kamailio:63X9IONf3ab8FIhZUAREVN2TQ0Tx4XzM1NN9wzTipyZPJoC3TngrT4ZOLS6ABYK2@localhost:3306/kamailio"
+#!define SQLCONN_AST "asterisk=>mysql://kamailio:63X9IONf3ab8FIhZUAREVN2TQ0Tx4XzM1NN9wzTipyZPJoC3TngrT4ZOLS6ABYK2@localhost:3306/kamailio"
 #!endif
 #!endif
 
@@ -84,6 +85,7 @@
 #!else
 #!define MULTIDOMAIN 0
 #!endif
+
 
 ### flag definitions and usage:
 # NOTE: flags are stored in each bit of an integer, there range is from 0-31 (32 bits)
@@ -213,6 +215,10 @@ listen = tls:INTERNAL_IP_ADDR:WSS_PORT advertise EXTERNAL_FQDN:WSS_PORT
 #!else
 listen = udp:INTERNAL_IP_ADDR:SIP_PORT
 listen = tcp:INTERNAL_IP_ADDR:SIP_PORT
+#!ifdef WITH_DMZ
+listen = udp:EXTERNAL_IP_ADDR:SIP_PORT
+listen = tcp:EXTERNAL_IP_ADDR:SIP_PORT
+#!endif 
 #!ifdef WITH_WEBSOCKETS
 listen = tls:INTERNAL_IP_ADDR:WSS_PORT
 #!endif
@@ -265,6 +271,13 @@ server_header = "Server: dSIPRouter/DSIP_VERSION"
 
 # disable Stream Control Tranmission Protocol (SCTP)
 enable_sctp = 0
+
+# enable/disable DMZ support
+#!ifdef WITH_DMZ
+mhomed=1
+#!else
+mhomed=0
+#!endif
 
 ####### Custom Parameters #########
 
@@ -319,7 +332,7 @@ server.pbx_invite_timeout_aftertry = 52000 desc "PBX INVITE timeout value if a S
 
 # DSIPRouter API Server Settings
 server.api_server = "https://127.0.0.1:5000" desc "URL to the DSIPRouter API Server"
-server.api_token = "admin" desc "API Token for DSIPRouter API Server"
+server.api_token = "9QFvxaUewjWsOv8cHctNXgsfHdko1QxGmjUm1zmOZlz3yATCZwrFTUmTZGpIVpyN" desc "API Token for DSIPRouter API Server"
 
 # Emergency Numbers
 server.emergency_numbers = "^([2-9]11|112|999|000|988|933)$" desc "Emergency Numbers"
@@ -849,6 +862,7 @@ request_route {
 
 	# SERVERNAT detection
 	route(SERVERNATDETECT);
+
 
 	# CANCEL processing
 	route(HANDLE_CANCEL);
@@ -1423,6 +1437,10 @@ failure_route[TELEBLOCK_FAILURE] {
 
 # Wrapper for relaying requests
 route[RELAY] {
+	
+	# DMZ direction detection
+	route(DMZ_DIR_DETECT);
+
 	# Enable the RTPEngine if required
 	route(IS_RTPE_REQUIRED);
 
@@ -2408,6 +2426,26 @@ route[NATDETECT] {
 	return;
 }
 
+# TODO: SERVERNATDETECT and DMZ_DIR_DETECT can be merged
+route[DMZ_DIR_DETECT] {
+#!ifdef WITH_DMZ
+	if (!isflagset(FLT_DST_INTERNAL_IP)) {
+		if (is_in_subnet($rd, "INTERNAL_IP_NET")) {
+			xlog("L_DBG","$si: DST_INTERNAL_IP public -> private");
+			setflag(FLT_DST_INTERNAL_IP);
+			setflag(FLT_DST_IPV4);
+		}
+	}
+	if (!isflagset(FLT_SRC_INTERNAL_IP)) {
+		if (is_in_subnet($si, "INTERNAL_IP_NET")) {
+			xlog("L_DBG","$si: SRC_INTERNAL_IP private -> public");
+			setflag(FLT_SRC_INTERNAL_IP);
+			setflag(FLT_SRC_IPV4);
+		}
+	}
+#!endif
+}
+
 # TODO: SERVERNAT for ipv4/ipv6 is detected during startup now, refactor this and dependent flags/logic accordingly
 route[SERVERNATDETECT] {
 #!ifdef WITH_SERVERNAT
@@ -2545,6 +2583,8 @@ route[RTPENGINEOFFER] {
 		$var(reflags) = "trust-address replace-origin replace-session-connection rtcp-mux-demux ICE=remove RTP/AVP";
 	}
 
+
+#!ifdef WITH_SERVERNAT
 	# for serverside NAT we may need to use one of the internal IPs as the media address
 	if (isflagset(FLT_DST_INTERNAL_IP)) {
 		if (isflagset(FLT_DST_IPV4)) {
@@ -2555,10 +2595,23 @@ route[RTPENGINEOFFER] {
 		}
 	}
 
+#!endif
+
+#!ifdef WITH_DMZ
+        if (isflagset(FLT_SRC_INTERNAL_IP) && !isflagset(FLT_DST_INTERNAL_IP))  {
+
+		xlog("L_DBG","RTPENGINEOFFER DMZ private->public selected");
+		$var(reflags)= $var(reflags) + " direction=private direction=public";
+	}
+	else if (!isflagset(FLT_SRC_INTERNAL_IP) && isflagset(FLT_DST_INTERNAL_IP)) {
+		$var(reflags)= $var(reflags) + " direction=public direction=private";
+	}
+#!endif 
+
 #!ifdef WITH_IPV6
 	# select interface within rtpengine based on IP versions (by default will use the IPv4 interface)
 	# only needed when not using the default interface (1st listen interface for rtpengine)
-	if (isflagset(FLT_SRC_IPV4) && isflagset(FLT_DST_IPV6)) {
+        if (isflagset(FLT_SRC_IPV4) && isflagset(FLT_DST_IPV6)) {
 		$var(reflags)= $var(reflags) + " direction=ipv4 direction=ipv6";
 	}
 	else if (isflagset(FLT_SRC_IPV6) && isflagset(FLT_DST_IPV4)) {
@@ -2568,6 +2621,8 @@ route[RTPENGINEOFFER] {
 		$var(reflags)= $var(reflags) + " direction=ipv6 direction=ipv6";
 	}
 #!endif
+
+
 
 	xlog("L_INFO", "reflags: $var(reflags)\n");
 	rtpengine_offer("$var(reflags)");
@@ -2606,6 +2661,7 @@ route[RTPENGINEANSWER] {
 		$var(reflags) = "trust-address replace-origin replace-session-connection rtcp-mux-demux ICE=remove RTP/AVP";
 	}
 
+#!ifdef WITH_SERVERNAT
 	# NOTE: no need to set direction= here, direction will be determined from the offer
 	# for serverside NAT we may need to use one of the internal IPs as the media address
 	if (isflagset(FLT_SRC_INTERNAL_IP)) {
@@ -2616,6 +2672,7 @@ route[RTPENGINEANSWER] {
 			$var(reflags)= $var(reflags) + " media-address=INTERNAL_IP6_ADDR";
 		}
 	}
+#!endif
 
 	xlog("L_INFO", "reflags: $var(reflags)\n");
 	rtpengine_answer("$var(reflags)");

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -497,7 +497,6 @@ loadmodule "siptrace.so"
 
 #!ifdef WITH_PUSH
 loadmodule "tsilo.so"
-loadmodule "rabbitmq.so"
 #!endif
 
 #======================================================================
@@ -840,7 +839,6 @@ modparam("siptrace", "trace_sl_acks", 1)
 
 #!ifdef WITH_PUSH
 modparam("htable", "htable", "push=>size=10;autoexpire=120;")
-modparam("rabbitmq", "url", "amqp://guest:guest@localhost:5672/kamailio")
 #!endif
 
 #======================================================================
@@ -2150,7 +2148,7 @@ route[SENDPUSH] {
 
         xlog("L_INFO", "[SENDPUSH] Sending teh push notofication.");  
 
-	rabbitmq_publish("kamailio", "routing_key", "application/json", "$avp(json_request)");
+	#rabbitmq_publish("kamailio", "routing_key", "application/json", "$avp(json_request)");
 	
 
 

--- a/kamailio/defaults/dsip_cdrinfo.sql
+++ b/kamailio/defaults/dsip_cdrinfo.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS `dsip_cdrinfo`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dsip_cdrinfo` (
   `gwgroupid` int(11) NOT NULL,
-  `email` varchar(100) NOT NULL DEFAULT '',
+  `email` varchar(255) NOT NULL DEFAULT '',
   `send_interval` varchar(255) NOT NULL DEFAULT '* * 1 * *',
   `last_sent` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`gwgroupid`)

--- a/resources/terraform/do/README.md
+++ b/resources/terraform/do/README.md
@@ -35,6 +35,12 @@ The following command will create a new instance of dSIPRouter based on the mast
 terraform apply -var branch=master -var dsiprouter_prefix=demo -var image=debian-11-x64
 ```
 
+If you want to create a demo instance of dSIPRouter in your Digitalocean environment with a DNS record use this.  Note, you will need to change the dns_demo_domain variable to a domain that you have hosted with DigitalOcean.
+
+```
+terraform apply -var branch=master -var image=debian-11-x64 -var dsiprouter_prefix=demo -var additional_commands='dsiprouter setcredentials -dc admin:ZmIwMTdmY2I5NjE4' -var dns_demo_enabled=1 -var dns_demo_domain=dsiprouter.org -var dns_demo_hostname=demo
+```
+
 7. Destroy your instance if you are done with it by using the terraform destory command
 
 ```

--- a/resources/terraform/do/main.tf
+++ b/resources/terraform/do/main.tf
@@ -18,7 +18,7 @@ data "digitalocean_ssh_key" "ssh_key" {
 resource "digitalocean_droplet" "dsiprouter" {
         name = "${var.dsiprouter_prefix}-dsip-${var.branch}${count.index}"
         count = var.number_of_environments
-        region = "nyc1"
+        region = "tor1"
         size="1gb"
         image=var.image
       	ssh_keys = [ data.digitalocean_ssh_key.ssh_key.fingerprint ]

--- a/resources/terraform/do/main.tf
+++ b/resources/terraform/do/main.tf
@@ -33,7 +33,16 @@ resource "digitalocean_droplet" "dsiprouter" {
 
         provisioner "remote-exec" {
           inline = [
-	"apt-get update -y && sleep 30 && apt-get install -y git && cd /opt && git clone https://github.com/dOpensource/dsiprouter.git -b ${var.branch} && cd dsiprouter && ./dsiprouter.sh install -all && ${var.additional_commands}"
+		"apt-get update -y && sleep 30 && apt-get install -y git && cd /opt && git clone https://github.com/dOpensource/dsiprouter.git -b ${var.branch} && cd dsiprouter && ./dsiprouter.sh install -all && ${var.additional_commands}"
         ]
       }
+}
+
+
+resource "digitalocean_record" "dns_demo_record" {
+  count = var.dns_demo_enabled
+  domain = var.dns_demo_domain
+  type = "A"
+  name = var.dns_demo_hostname
+  value = digitalocean_droplet.dsiprouter.*.ipv4_address[count.index]
 }

--- a/resources/terraform/do/variables.tf
+++ b/resources/terraform/do/variables.tf
@@ -10,6 +10,21 @@ variable "dsiprouter_prefix" {
 	default=""
 }
 
+variable "dns_demo_domain" {
+	type=string
+	default=""
+}
+
+variable  "dns_demo_enabled" {
+	type=number
+	default=0
+}
+
+variable "dns_demo_hostname" {
+	type=string
+	default="demo"
+}
+
 variable "number_of_environments" {
 	type=number
 	default="1"


### PR DESCRIPTION
- Added DMZ Support
- Fixed issue with Kamailio.cfg
- Fixed issues with install scripts
- Fixed issues with install scripts
- Updated getInternalCIDR with support for DMZ
- Terraform - Added support for adding a hostname record to DNS
- Added push notification updates
- Added support for spinning up a demo server
- Removed Rabbit MQ logic
- Increase CDR Field Sizes
- Fix Missing Kamailio Config Subst
