### PR TITLE
Hotfixes for v0.72

### DIFF
--- a/docs/source/user/upgrade.rst
+++ b/docs/source/user/upgrade.rst
@@ -1,9 +1,13 @@
 Upgrading dSIPRouter 
 ============================================
 
-Auto Upgrade Feature (Released 0.72)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The dSIPRouter auto upgrade feature was released in 0.72.  It allows you to upgrade dSIPRouter from the User Interface(UI) and the command line.  If you are upgrading from 0.70 you will need to use the command line option since the 0.70 version doesn't have the upgrade feature builtin. Upgrading from 0.70 doesn't require a dSIPRouter Core Subscription license because this is the first release of the upgrade framework unless you need support during the upgrade process.  However, future releases of dSIPRouter will require a Core Subscription License, which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.  
+Auto Upgrade Feature
+^^^^^^^^^^^^^^^^^^^^
+The dSIPRouter auto upgrade feature was released in 0.72.
+It allows you to upgrade dSIPRouter from the User Interface(UI) and the command line.
+If you are upgrading from 0.70 you will need to use the command line option since the 0.70 version doesn't have the upgrade feature builtin.
+Upgrading from 0.70 doesn't require a dSIPRouter Core Subscription license because this is the first release of the upgrade framework unless you need support during the upgrade process.
+However, future releases of dSIPRouter will require a Core Subscription License, which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.
 
 .. image:: images/upgrade_up_to_date.png
         :align: center
@@ -21,27 +25,17 @@ You can upgrade from 0.70 by doing the following
 
 3. Login to the dSIPRouter UI to validate that the upgrade was successful.  
 
-Note, if the upgrade fails you can purchase a dSIPRouter Core Subscription which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.This will provide you with support hours so that we can help with the upgrade.
+Note, if the upgrade fails you can purchase a dSIPRouter Core Subscription which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.
+This will provide you with support hours so that we can help with the upgrade.
 
 Upgrade 0.70 to 0.72
 ^^^^^^^^^^^^^^^^^^^^
-You can upgrade from 0.70 by doing the following
+This upgrade path is deprecated. Upgrade to the **0.721** release instead.
 
-1. SSH to your dSIPRouter Instance
-2. Run the following command
-
-.. code-block:: bash
-
-   curl -s https://raw.githubusercontent.com/dOpensource/dsiprouter/v0.72/resources/upgrade/v0.72/scripts/bootstrap.sh | bash
-
-3. Login to the dSIPRouter UI to validate that the upgrade was successful.  
-
-Note, if the upgrade fails you can purchase a dSIPRouter Core Subscription which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.This will provide you with support hours so that we can help with the upgrade.
-
-Upgrade 0.644 to 0.72
+Upgrade 0.644 to 0.70
 ^^^^^^^^^^^^^^^^^^^^^
-There is no automated upgrade available from 0.644 to 0.72.  Support is available via a dSIPRouter Core Subscription which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.This will provide you with support hours so that we can help with the upgrade.
-
+There is no automated upgrade available from 0.644 to 0.70.
+Support is available via a dSIPRouter Core Subscription which can be purchased from the `dSIPRouter Marketplace <https://dopensource.com/product/dsiprouter-core/>`_.This will provide you with support hours so that we can help with the upgrade.
 
 Upgrade 0.621 to 0.63
 ^^^^^^^^^^^^^^^^^^^^^

--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -798,8 +798,8 @@ function renewSSLCert() {
     # Don't try to renew if using wildcard certs
     openssl x509 -in ${DSIP_SSL_CERT} -noout -subject | grep "CN\s\?=\s\?*." &>/dev/null
     if (( $? == 0 )); then
-	printwarn "Wildcard certifcates are being used! LetsEncrypt certifcates can't automatically renew wildcard certificates"    
-   	return
+	    printwarn "Wildcard certifcates are being used! LetsEncrypt certifcates can't automatically renew wildcard certificates"
+   	    return
     fi
 
     # Don't renew if a default cert was uploaded

--- a/gui/dsiprouter.py
+++ b/gui/dsiprouter.py
@@ -3,8 +3,6 @@
 # make sure the generated source files are imported instead of the template ones
 import sys
 
-from util.pyasync import proc
-
 sys.path.insert(0, '/etc/dsiprouter/gui')
 
 # all of our standard and project file imports

--- a/gui/modules/api/licensemanager/routes.py
+++ b/gui/modules/api/licensemanager/routes.py
@@ -90,13 +90,13 @@ def cmpDsipLicense(lc, payload=None):
     settings_lc_combo = getattr(settings, lc.type)
     if len(settings_lc_combo) == 0:
         payload['data'].append(False)
-        payload['msg'] = 'license has is not registered to this node'
+        payload['msg'] = 'license is not registered to this node'
         return payload
 
     settings_lc = WoocommerceLicense(key_combo=settings_lc_combo, decrypt=True)
     if lc != settings_lc:
         payload['data'].append(False)
-        payload['msg'] = 'license has is not registered to this node'
+        payload['msg'] = 'license is not registered to this node'
         return payload
 
     payload['data'].append(True)
@@ -159,7 +159,7 @@ def validateLicense():
             return jsonify(response_payload), StatusCodes.HTTP_OK
 
         # local dsip validation
-        # response_payload = cmpDsipLicense(lc, response_payload)
+        response_payload = cmpDsipLicense(lc, response_payload)
 
         return jsonify(response_payload), StatusCodes.HTTP_OK
 

--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -5,7 +5,7 @@ cryptography
 dnspython
 docker
 docutils<0.17,>=0.12
-Flask~=2.0
+Flask~=2.2.0
 Flask_WTF
 itsdangerous==2.0.1
 Jinja2==3.0.3

--- a/gui/settings.py
+++ b/gui/settings.py
@@ -168,7 +168,7 @@ BACKUP_FOLDER = '/var/backups/dsiprouter'
 TRANSNEXUS_AUTHSERVICE_ENABLED = 0
 TRANSNEXUS_AUTHSERVICE_HOST = 'outbound.sip.clearip.com:5060'
 TRANSNEXUS_VERIFYSERVICE_ENABLED = 0
-TRANSNEXUS_VERIFYSERVICE_HOST =  "inbound.sip.clearip.com:5060"
+TRANSNEXUS_VERIFYSERVICE_HOST = 'inbound.sip.clearip.com:5060'
 
 # STIR/SHAKEN Settings
 # TODO: marked for review, these settings should be synced across cluster in the DB

--- a/kamailio/almalinux/8.sh
+++ b/kamailio/almalinux/8.sh
@@ -25,7 +25,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # TODO: we should detect if SELINUX is enabled and if so add proper permissions for kamailio, dsip, etc..
     # Disable SELinux

--- a/kamailio/amzn/2.sh
+++ b/kamailio/amzn/2.sh
@@ -23,7 +23,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # link latest version of cmake
     ln -sf /bin/cmake3 /usr/local/bin/cmake

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -2782,9 +2782,7 @@ route[RTPENGINEOFFER] {
 #!endif
 
 #!ifdef WITH_DMZ
-        if (isflagset(FLT_SRC_INTERNAL_IP) && !isflagset(FLT_DST_INTERNAL_IP))  {
-
-		xlog("L_DBG","RTPENGINEOFFER DMZ private->public selected");
+	if (isflagset(FLT_SRC_INTERNAL_IP) && !isflagset(FLT_DST_INTERNAL_IP))  {
 		$var(reflags)= $var(reflags) + " direction=private direction=public";
 	}
 	else if (!isflagset(FLT_SRC_INTERNAL_IP) && isflagset(FLT_DST_INTERNAL_IP)) {

--- a/kamailio/debian/10.sh
+++ b/kamailio/debian/10.sh
@@ -26,7 +26,7 @@ function install {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # create kamailio user and group
     mkdir -p /var/run/kamailio

--- a/kamailio/debian/11.sh
+++ b/kamailio/debian/11.sh
@@ -26,7 +26,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # create kamailio user and group
     mkdir -p /var/run/kamailio

--- a/kamailio/debian/9.sh
+++ b/kamailio/debian/9.sh
@@ -22,7 +22,7 @@ function install {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # create kamailio user and group
     mkdir -p /var/run/kamailio

--- a/kamailio/rhel/8.sh
+++ b/kamailio/rhel/8.sh
@@ -23,7 +23,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # TODO: we should detect if SELINUX is enabled and if so add proper permissions for kamailio, dsip, etc..
     # Disable SELinux

--- a/kamailio/rocky/8.sh
+++ b/kamailio/rocky/8.sh
@@ -24,7 +24,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # TODO: we should detect if SELINUX is enabled and if so add proper permissions for kamailio, dsip, etc..
     # Disable SELinux

--- a/kamailio/ubuntu/20.sh
+++ b/kamailio/ubuntu/20.sh
@@ -26,7 +26,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # create kamailio user and group
     mkdir -p /var/run/kamailio

--- a/kamailio/ubuntu/22.sh
+++ b/kamailio/ubuntu/22.sh
@@ -26,7 +26,7 @@ function install() {
     python3 -m venv /opt/certbot/
     /opt/certbot/bin/pip install --upgrade pip
     /opt/certbot/bin/pip install certbot
-    ln -s /opt/certbot/bin/certbot /usr/bin/certbot
+    ln -sf /opt/certbot/bin/certbot /usr/bin/certbot
 
     # create kamailio user and group
     mkdir -p /var/run/kamailio

--- a/resources/git/hooks/pre-commit
+++ b/resources/git/hooks/pre-commit
@@ -30,14 +30,14 @@ EXCLUDE_DIRS=( )
 REQUIREMENTS_FILE="requirements.txt"
 # pipreqs only catches stdlib libraries
 INCLUDE_LIBS=(
-	'Jinja2==3.0.3' 'Werkzeug==2.0.2' 'itsdangerous==2.0.1' 'Flask==1.1.2' 'docutils<0.17,>=0.12'
+	'Jinja2==3.0.3' 'Werkzeug==2.0.2' 'itsdangerous==2.0.1' 'Flask~=2.2.0' 'docutils<0.17,>=0.12'
 	'mysqlclient' 'docker' 'sphinx' 'recommonmark' 'sphinxcontrib-httpdomain' 'sphinx-rtd-theme'
-	'pem' 'twilio' 'SQLAlchemy~=2.0'
+	'pem' 'twilio' 'SQLAlchemy~=2.0' 'acme'
 )
 # excludes for conflicting libs
 EXCLUDE_LIBS=(
-	'Jinja2' 'Werkzeug' 'itsdangerous' 'Flask' 'docker_py' 'pyspark' 'acme.hello' 'josepy'
-	'MySQL-python' 'SQLAlchemy' 'certbot'
+	'Jinja2' 'Werkzeug' 'itsdangerous' 'Flask' 'docker_py' 'pyspark' 'acme.hello' 'MySQL-python'
+	'SQLAlchemy' 'certbot'
 )
 
 

--- a/resources/upgrade/v0.721/scripts/bootstrap.sh
+++ b/resources/upgrade/v0.721/scripts/bootstrap.sh
@@ -2,7 +2,7 @@
 
 export BOOTSTRAPPING_UPGRADE=1
 export DSIP_PROJECT_DIR='/tmp/dsiprouter'
-TAG_NAME='v0.721'
+TAG_NAME='v0.721-rel'
 REPO_URL='https://github.com/dOpensource/dsiprouter.git'
 rm -f /etc/dsiprouter/.requirementsinstalled
 rm -rf "$DSIP_PROJECT_DIR" 2>/dev/null


### PR DESCRIPTION
  - pin Flask version to 2.2.x
  - fix tagging format
  - update upgrade documentation
  - add support for migrating trnasnexus licenses
  - various bug fixes in migration script
  - fix certbot overwrite on reinstall

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# Date:      Thu Apr 27 13:03:19 2023 -0400
#
# On branch v0.721
# Your branch is ahead of 'origin/v0.721' by 1 commit.
#   (use "git push" to publish your local commits)
#
# Changes to be committed:
#	modified:   docs/source/user/upgrade.rst
#	modified:   dsiprouter.sh
#	modified:   gui/dsiprouter.py
#	modified:   gui/modules/api/licensemanager/routes.py
#	modified:   gui/requirements.txt
#	modified:   gui/settings.py
#	modified:   kamailio/almalinux/8.sh
#	modified:   kamailio/amzn/2.sh
#	modified:   kamailio/configs/kamailio.cfg
#	modified:   kamailio/debian/10.sh
#	modified:   kamailio/debian/11.sh
#	modified:   kamailio/debian/9.sh
#	modified:   kamailio/rhel/8.sh
#	modified:   kamailio/rocky/8.sh
#	modified:   kamailio/ubuntu/20.sh
#	modified:   kamailio/ubuntu/22.sh
#	modified:   resources/git/hooks/pre-commit
#	modified:   resources/upgrade/v0.721/scripts/bootstrap.sh
#	modified:   resources/upgrade/v0.721/scripts/migrate.sh
#
