### PR TITLE
Bug/debian12 fixes vultr test

### DIFF
--- a/dnsmasq/debian/12.sh
+++ b/dnsmasq/debian/12.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Debug this script if in debug mode
+(( $DEBUG == 1 )) && set -x
+
+# Import dsip_lib utility / shared functions if not already
+if [[ "$DSIP_LIB_IMPORTED" != "1" ]]; then
+    . ${DSIP_PROJECT_DIR}/dsiprouter/dsip_lib.sh
+fi
+
+function install() {
+    
+    # mask the service before running package manager to avoid faulty startup errors
+    systemctl mask dnsmasq.service
+
+    apt-get install -y dnsmasq
+
+    if (( $? != 0 )); then
+        printerr 'Failed installing new dns stack'
+        return 1
+    fi
+
+    # make sure we unmask before configuring the service ourselves
+    systemctl unmask dnsmasq.service
+
+    # configure dnsmasq systemd service
+    #cp -f ${DSIP_PROJECT_DIR}/dnsmasq/systemd/dnsmasq-v1.service /lib/systemd/system/dnsmasq.service
+    #chmod 644 /lib/systemd/system/dnsmasq.service
+    #systemctl daemon-reload
+    systemctl enable dnsmasq
+
+    # backup the original resolv.conf
+    [[ ! -e "${BACKUPS_DIR}/etc/resolv.conf" ]] && {
+        mkdir -p ${BACKUPS_DIR}/etc/
+        cp -df /etc/resolv.conf ${BACKUPS_DIR}/etc/resolv.conf
+    }
+
+    # make dnsmasq the DNS provider
+    rm -f /etc/resolv.conf
+    cp -f ${DSIP_PROJECT_DIR}/dnsmasq/configs/resolv.conf /etc/resolv.conf
+
+    # for some reason the defaults on systemd-networkd are not followed after changing the above
+    # so we give the interfaces explicit rules to make sure DNS servers are resolved via DHCP on the ifaces
+    # see systemd.network and systemd.networkd for more information
+    mkdir -p /etc/systemd/network/
+    cp -f ${DSIP_PROJECT_DIR}/dnsmasq/configs/systemd.network /etc/systemd/network/99-dsiprouter.network
+
+    # restart systemd network services
+    systemctl restart systemd-networkd 
+    if (( $? != 0 )); then
+        printerr 'failed loading new systemd network configurations..'
+        printwarn 'reverting network changes'
+        rm -f /etc/systemd/network/99-dsiprouter.network
+        systemctl restart systemd-networkd
+        return 1
+    fi
+
+    # Reload resolvconf if it's installed
+    systemctl is-active resolvconf
+    if (( $? != 0 )); then
+             printwarn 'resolvconf is not installed'
+
+    else
+             printwarn 'resolvconf is installed'
+	     # copy the DNS servers from the orig /etc/resolv.conf
+             #cp -df ${BACKUPS_DIR}/etc/resolv.conf /run/resolvconf/resolv.conf
+    	     # tell dnsmasq to grab dns servers from resolvconf
+             #export DNSMASQ_RESOLV_FILE="/run/resolvconf/resolv.conf"
+    fi
+    
+  # Reload systemctl-resolved if it's installed
+    systemctl is-active systemctl-resolved
+    if (( $? != 0 )); then
+             printwarn 'systemctl-resolved is not installed'
+    else
+    	     # we only need the dhcp dynamic dns servers feature of systemd-resolved, everything else is turned off
+   	      mkdir -p /etc/systemd/resolved.conf.d/
+    	     cp -f ${DSIP_PROJECT_DIR}/dnsmasq/configs/systemdresolved.conf /etc/systemd/resolved.conf.d/99-dsiprouter.conf
+	     systemctl restart systemctl-resolved
+    	     # tell dnsmasq to grab dns servers from systemd-resolved
+             export DNSMASQ_RESOLV_FILE="/run/systemd/resolve/resolv.conf"
+    fi
+
+
+    envsubst <${DSIP_PROJECT_DIR}/dnsmasq/configs/dnsmasq_sh.conf >/etc/dnsmasq.conf
+
+    return 0
+}
+
+function uninstall() {
+
+    # stop and disable services
+    systemctl disable dnsmasq
+    systemctl stop dnsmasq
+
+    # uninstall packages
+    apt-get remove -y --purge dnsmasq
+
+    # remove our systemd-resolved configurations
+    rm -f /etc/systemd/resolved.conf.d/99-dsiprouter.conf
+
+    # remove the systemd.network rules
+    rm -f /etc/systemd/network/99-dsiprouter.network
+
+    # restore original resolv.conf
+    cp -df ${BACKUPS_DIR}/etc/resolv.conf /etc/resolv.conf
+
+    # restart systemd.networkd with the original rules
+    systemctl restart systemd-networkd
+
+    # update resolv.conf / restart systemd-resolved with new configs
+    systemctl restart systemd-resolved
+
+    # cleanup backup files
+    rm -f ${BACKUPS_DIR}/etc/resolv.conf
+
+    return 0
+}
+
+case "$1" in
+    install)
+        install && exit 0 || exit 1
+        ;;
+    uninstall)
+        uninstall && exit 0 || exit 1
+        ;;
+    *)
+        printerr "Usage: $0 [install | uninstall]"
+        exit 1
+        ;;
+esac

--- a/kamailio/debian/12.sh
+++ b/kamailio/debian/12.sh
@@ -122,9 +122,10 @@ EOF
         return 1
     }
 
+    # Remove ufw if installed
+    apt-get remove -y ufw
     # Enable and start firewalld if not already running
     systemctl enable firewalld
-    systemctl start firewalld
 
     # Setup firewall rules
     firewall-cmd --zone=public --add-port=${KAM_SIP_PORT}/udp --permanent
@@ -132,7 +133,10 @@ EOF
     firewall-cmd --zone=public --add-port=${KAM_SIPS_PORT}/tcp --permanent
     firewall-cmd --zone=public --add-port=${KAM_WSS_PORT}/tcp --permanent
     firewall-cmd --zone=public --add-port=${KAM_DMQ_PORT}/udp --permanent
+    firewall-cmd --zone=public --add-port=22/tcp --permanent
     firewall-cmd --reload
+
+    systemctl start firewalld
 
     # Configure Kamailio systemd service
     cp -f ${DSIP_PROJECT_DIR}/kamailio/systemd/kamailio-v2.service /lib/systemd/system/kamailio.service

--- a/kamailio/debian/12.sh
+++ b/kamailio/debian/12.sh
@@ -60,6 +60,9 @@ EOF
     # Update repo sources cache
     apt-get update -y
 
+    # Remove ufw if installed
+    apt-get remove -y ufw
+    
     # Install Kamailio packages
     apt-get install -y kamailio kamailio-mysql-modules kamailio-extra-modules \
         kamailio-tls-modules kamailio-websocket-modules kamailio-presence-modules \
@@ -122,8 +125,6 @@ EOF
         return 1
     }
 
-    # Remove ufw if installed
-    apt-get remove -y ufw
     # Enable and start firewalld if not already running
     systemctl enable firewalld
 

--- a/kamailio/debian/12.sh
+++ b/kamailio/debian/12.sh
@@ -12,6 +12,9 @@ function install() {
     local KAM_SOURCES_LIST="/etc/apt/sources.list.d/kamailio.list"
     local KAM_PREFS_CONF="/etc/apt/preferences.d/kamailio.pref"
     local NPROC=$(nproc)
+    
+    # Remove ufw if installed
+    apt-get remove -y ufw
 
     # Install Dependencies
     apt-get install -y curl wget sed gawk vim perl uuid-dev libssl-dev logrotate rsyslog \
@@ -60,8 +63,6 @@ EOF
     # Update repo sources cache
     apt-get update -y
 
-    # Remove ufw if installed
-    apt-get remove -y ufw
     
     # Install Kamailio packages
     apt-get install -y kamailio kamailio-mysql-modules kamailio-extra-modules \


### PR DESCRIPTION
- Fixes installation issues on Debian 12 caused by dnsmasq, which are trigged by different cloud providers deciding to use different DNS stacks (resolvconf or systemd-resolved)
 
- Added support for Vultr since many of our users are using the cloud provider.  Another issue with Vultr was that they use ufw as a system firewall.  We used firewalld in our installation scripts so they were conflicting

- (Vultr Only) Added  logic to set the EXTERNAL_FQDN based on the hostname of the server versus the FQDN that's provided when doing a reverse dns lookup on the Vultr cloud platform

- Performed tests on DigitalOcean (our primary dev environment) and Vultr

Fixes #275 