### PR TITLE
Bug/dnsmasq optional

### DIFF
--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -3781,7 +3781,8 @@ function processCMD() {
                         ;;
                     -kam|--kamailio)
                         DEFAULT_SERVICES=0
-                        RUN_COMMANDS+=(installSipsak installCron installDnsmasq installMysql installKamailio)
+                        #RUN_COMMANDS+=(installSipsak installCron installDnsmasq installMysql installKamailio)
+                        RUN_COMMANDS+=(installSipsak installCron installMysql installKamailio)
                         shift
                         ;;
                     -dsip|--dsiprouter)
@@ -3798,7 +3799,8 @@ function processCMD() {
                     -all|--all)
                         DEFAULT_SERVICES=0
                         DISPLAY_LOGIN_INFO=1
-                        RUN_COMMANDS+=(installSipsak installCron installDnsmasq installMysql installKamailio installNginx installDsiprouter installRTPEngine)
+                        #RUN_COMMANDS+=(installSipsak installCron installDnsmasq installMysql installKamailio installNginx installDsiprouter installRTPEngine)
+                        RUN_COMMANDS+=(installSipsak installCron installMysql installKamailio installNginx installDsiprouter installRTPEngine)
                         shift
                         ;;
                     # DEPRECATED: marked for removal in v0.80

--- a/dsiprouter/systemd/dsiprouter-v1.service
+++ b/dsiprouter/systemd/dsiprouter-v1.service
@@ -12,8 +12,8 @@ Description=dSIPRouter Service
 DefaultDependencies=no
 Requires=basic.target network.target
 After=network.target network-online.target systemd-journald.socket basic.target
-After=rsyslog.service mariadb.service nginx.service
-Wants=nginx.service mariadb.service
+After=rsyslog.service mariadb.service nginx.service kamailio.service
+Wants=nginx.service mariadb.service kamailio.service
 StartLimitInterval=30
 StartLimitBurst=3
 

--- a/dsiprouter/systemd/dsiprouter-v2.service
+++ b/dsiprouter/systemd/dsiprouter-v2.service
@@ -12,8 +12,8 @@ Description=dSIPRouter Service
 DefaultDependencies=no
 Requires=basic.target network.target
 After=network.target network-online.target systemd-journald.socket basic.target
-After=rsyslog.service mariadb.service nginx.service
-Wants=nginx.service mariadb.service
+After=rsyslog.service mariadb.service nginx.service kamailio.service
+Wants=nginx.service mariadb.service kamailio.service
 StartLimitIntervalSec=30
 StartLimitBurst=3
 


### PR DESCRIPTION
- Removed dnsmasq as a standard component of dSIPRouter during a non-clustered installed
- Request kamailio.service to start before dSIPRouter.  Otherwise, dSIPRouter will not start and provide a poor experience to new users.