### PR TITLE
Load Balancing Bug Fixes

### DIFF
--- a/gui/database/__init__.py
+++ b/gui/database/__init__.py
@@ -495,6 +495,22 @@ class Dispatcher(object):
     Documentation: `dispatcher table <https://kamailio.org/docs/db-tables/kamailio-db-5.5.x.html#gen-db-dispatcher>`_
     """
 
+    DST_ALG = {
+        'ROUND_ROBIN': 4,
+        'PRIORITY_BASED': 8,
+        'WEIGHT_BASED': 9,
+        'LOAD_DISTRIBUTION': 10,
+        'RELATIVE_WEIGHT': 11,
+        'PARALLEL_FORKING': 12
+    }
+    FLAGS = {
+        'INACTIVE_DST': 1,
+        'TRYING_DST': 2,
+        'DISABLED_DST': 4,
+        'KEEP_ALIVE': 8,
+        'SKIP_DNS': 16
+    }
+
     def __init__(self, setid, destination, flags=None, priority=None, description='', rweight=0, signalling='proxy', media='proxy'):
         self.setid = setid
         self.destination = safeFormatSipUri(destination)

--- a/gui/modules/api/api_routes.py
+++ b/gui/modules/api/api_routes.py
@@ -744,6 +744,8 @@ def getEndpointGroup(gwgroupid):
 
         db = startSession()
 
+        gwgroupid = int(gwgroupid)
+
         endpointgroup = db.query(GatewayGroups).filter(GatewayGroups.id == gwgroupid).first()
         if endpointgroup is not None:
             gwgroup_data['name'] = strFieldsToDict(endpointgroup.description)['name']
@@ -775,15 +777,26 @@ def getEndpointGroup(gwgroupid):
         gwgroup_data['auth'] = auth
 
         gwgroup_data['endpoints'] = []
-        weightList = {}
-        endpoints = db.query(Gateways).filter(Gateways.gwid.in_(endpointgroup.gwlist.split(','))).all()
-        dispatcher_rows = db.query(Dispatcher).filter(Dispatcher.setid == gwgroupid).all()
+        endpoint_weights = {}
+        endpoint_keepalives = {}
+        endpoints = db.query(Gateways).filter(
+            Gateways.gwid.in_(endpointgroup.gwlist.split(','))
+        ).all()
+        dispatcher_rows = db.query(Dispatcher).filter(
+            (Dispatcher.setid == gwgroupid) |
+            (Dispatcher.setid == gwgroupid + 1000)
+        ).all()
         if dispatcher_rows is not None:
             for row in dispatcher_rows:
                 dst_host = row.destination.split(':', maxsplit=1)[1]
                 attrs = row.attrsToDict()
                 if attrs.get('rweight', None) is not None:
-                    weightList[dst_host] = attrs['rweight']
+                    endpoint_weights[dst_host] = attrs['rweight']
+                # TODO: make this check part of the DB object methods
+                if Dispatcher.FLAGS['KEEP_ALIVE'] & row.flags:
+                    endpoint_keepalives[dst_host] = 1
+                else:
+                    endpoint_keepalives[dst_host] = 0
         for endpoint in endpoints:
             host_split = endpoint.address.split(':')
             attrs_dict = endpoint.attrsToDict()
@@ -794,7 +807,8 @@ def getEndpointGroup(gwgroupid):
                 'signalling': attrs_dict['signalling'],
                 'media': attrs_dict['media'],
                 'description': strFieldsToDict(endpoint.description)['name'],
-                'rweight': weightList[endpoint.address] if endpoint.address in weightList else 0,
+                'rweight': endpoint_weights[endpoint.address] if endpoint.address in endpoint_weights else 0,
+                'keepalive': endpoint_keepalives[endpoint.address] if endpoint.address in endpoint_keepalives else 0,
                 'maintmode': ''
             })
             gwgroup_data['strip'] = endpoint.strip
@@ -915,8 +929,9 @@ def updateEndpointGroups(gwgroupid=None):
                     port:<int>,
                     signalling:<string>,
                     media:<string>,
-                    description:<string>
-                    rweight:<int>
+                    description:<string>,
+                    rweight:<int>,
+                    keepalive:<int>
                 },
                 ...
             ],
@@ -1039,8 +1054,8 @@ def updateEndpointGroups(gwgroupid=None):
             if 'auth' in request_payload and 'type' in request_payload['auth'] else ""
 
         if 'fusionpbx' in request_payload:
-            fusionpbxenabled = request_payload['fusionpbx']['enabled'] \
-                if 'enabled' in request_payload['fusionpbx'] else None
+            fusionpbxenabled = int(request_payload['fusionpbx']['enabled']) \
+                if 'enabled' in request_payload['fusionpbx'] else 0
             fusionpbxdbhost = request_payload['fusionpbx']['dbhost'] \
                 if 'dbhost' in request_payload['fusionpbx'] else None
             fusionpbxdbuser = request_payload['fusionpbx']['dbuser'] \
@@ -1114,11 +1129,18 @@ def updateEndpointGroups(gwgroupid=None):
                     raise http_exceptions.BadRequest("Endpoint hostname/address is required")
 
                 host = endpoint['host']
-                port = endpoint['port'] if endpoint.get('port', None) is not None else 5060
+                port = int(endpoint['port']) if endpoint.get('port', None) is not None else 5060
                 signalling = endpoint['signalling'] if 'signalling' in endpoint else 'proxy'
                 media = endpoint['media'] if 'media' in endpoint else 'proxy'
                 name = endpoint['description'] if 'description' in endpoint else ''
-                rweight = endpoint['rweight'] if endpoint.get('rweight', None) is not None else 0
+                rweight = int(endpoint['rweight']) if endpoint.get('rweight', None) is not None else 0
+                keepalive = int(endpoint['keepalive']) if endpoint.get('keepalive', None) is not None else 0
+
+                flags = 0
+                if keepalive > 0:
+                    flags += Dispatcher.FLAGS['KEEP_ALIVE']
+                if rweight == 0:
+                    flags += Dispatcher.FLAGS['DISABLED_DST']
 
                 sip_addr = safeUriToHost(host, default_port=port)
                 if sip_addr is None:
@@ -1140,15 +1162,18 @@ def updateEndpointGroups(gwgroupid=None):
                         signalling=signalling, media=media)
 
                 # Create dispatcher group with the set id being the gateway group id
-                dispatcher = Dispatcher(setid=gwgroupid, destination=sip_addr, description=name, rweight=rweight,
+                sip_uri = f'sip:{sip_addr}'
+                dispatcher = Dispatcher(setid=gwgroupid, destination=sip_uri, flags=flags, description=name, rweight=rweight,
                     signalling=signalling, media=media)
                 db.add(dispatcher)
 
                 # Create dispatcher for FusionPBX external interface if FusionPBX feature is enabled
-                if int(fusionpbxenabled) > 0:
-                    sip_addr_external = safeUriToHost(host, default_port=5080)
+                if fusionpbxenabled:
+                    sip_uri_ext = f'sip:{safeStripPort(sip_addr)}:5080'
+                    setid_ext = gwgroupid + 1000
                     # Add 1000 to the gwgroupid so that the setid for the FusionPBX external interface is 1000 apart
-                    dispatcher = Dispatcher(setid=gwgroupid + 1000, destination=sip_addr_external, description=name, rweight=rweight)
+                    dispatcher = Dispatcher(setid=setid_ext, destination=sip_uri_ext, flags=flags, description=name, rweight=rweight,
+                        signalling=signalling, media=media)
                     db.add(dispatcher)
 
                 db.add(Gateway)
@@ -1175,11 +1200,18 @@ def updateEndpointGroups(gwgroupid=None):
                 raise http_exceptions.BadRequest("Endpoint hostname/address is required")
 
             host = endpoint['host']
-            port = endpoint['port'] if endpoint.get('port', None) is not None else 5060
+            port = int(endpoint['port']) if endpoint.get('port', None) is not None else 5060
             signalling = endpoint['signalling'] if 'signalling' in endpoint else 'proxy'
             media = endpoint['media'] if 'media' in endpoint else 'proxy'
             name = endpoint['description'] if 'description' in endpoint else ''
-            rweight = endpoint['rweight'] if endpoint.get('rweight', None) is not None else 0
+            rweight = int(endpoint['rweight']) if endpoint.get('rweight', None) is not None else 0
+            keepalive = int(endpoint['keepalive']) if endpoint.get('keepalive', None) is not None else 0
+
+            flags = 0
+            if keepalive > 0:
+                flags += Dispatcher.FLAGS['KEEP_ALIVE']
+            if rweight == 0:
+                flags += Dispatcher.FLAGS['DISABLED_DST']
 
             sip_addr = safeUriToHost(host, default_port=port)
             if sip_addr is None:
@@ -1201,15 +1233,18 @@ def updateEndpointGroups(gwgroupid=None):
                     signalling=signalling, media=media)
 
             # Create dispatcher group with the set id being the gateway group id
-            dispatcher = Dispatcher(setid=gwgroupid, destination=sip_addr, description=name, rweight=rweight,
+            sip_uri = f'sip:{sip_addr}'
+            dispatcher = Dispatcher(setid=gwgroupid, destination=sip_uri, flags=flags, description=name, rweight=rweight,
                 signalling=signalling, media=media)
             db.add(dispatcher)
 
             # Create dispatcher for FusionPBX external interface if FusionPBX feature is enabled
-            if int(fusionpbxenabled) > 0:
-                sip_addr_external = safeUriToHost(safeStripPort(host), default_port=5080)
+            if fusionpbxenabled:
+                sip_uri_ext = f'sip:{safeStripPort(sip_addr)}:5080'
+                setid_ext = gwgroupid + 1000
                 # Add 1000 to the gwgroupid so that the setid for the FusionPBX external interface is 1000 apart
-                dispatcher = Dispatcher(setid=gwgroupid + 1000, destination=sip_addr_external, description=name, rweight=rweight)
+                dispatcher = Dispatcher(setid=setid_ext, destination=sip_uri_ext, flags=flags, description=name, rweight=rweight,
+                    signalling=signalling, media=media)
                 db.add(dispatcher)
 
             # we ignore the given gwid and allow DB to assign one instead
@@ -1227,15 +1262,18 @@ def updateEndpointGroups(gwgroupid=None):
             # allow updating single fields (if not provided set to current value)
             host = endpoint['host'] if 'host' in endpoint else current_endpoint['address'].split(':')[0]
             if 'port' in endpoint and endpoint['port'] is not None:
-                port = endpoint['port']
+                port = int(endpoint['port'])
             else:
                 tmp = current_endpoint['address'].split(':')
                 port = int(tmp[1]) if len(tmp) > 1 else 5060
             signalling = endpoint['signalling'] if 'signalling' in endpoint else endpoint_attrs['signalling']
             media = endpoint['media'] if 'media' in endpoint else endpoint_attrs['media']
             name = endpoint['description'] if 'description' in endpoint else endpoint_fields['name']
-            rweight = endpoint['rweight'] if endpoint.get('rweight', None) is not None else 0
             endpoint_fields['name'] = name
+
+            # fields not in dr_gateways attributes we set to None if not updated and check it after querying dispatcher
+            rweight = int(endpoint['rweight']) if endpoint.get('rweight', None) is not None else None
+            keepalive = int(endpoint['keepalive']) if endpoint.get('keepalive', None) is not None else None
 
             if len(host) == 0:
                 raise http_exceptions.BadRequest("Endpoint hostname/address is required")
@@ -1277,43 +1315,75 @@ def updateEndpointGroups(gwgroupid=None):
                     # remove addr_id field from endpoint description
                     endpoint_fields.pop("addr_id", None)
 
-            # update the endpoint
-            db.query(Gateways).filter(Gateways.gwid == gwid).update({
-                "description": dictToStrFields(endpoint_fields),
-                "address": sip_addr,
-                "strip": strip,
-                "pri_prefix": prefix,
-                'attrs': Gateways.buildAttrs(gwid=gwid, type=current_endpoint['type'], signalling=signalling, media=media)
-            }, synchronize_session=False)
+            # find the current entry in dr_gateways
+            ep_gateway = db.query(Gateways).filter(Gateways.gwid == gwid).first()
+            old_sip_uri = f'sip:{ep_gateway.address}'
+            old_sip_uri_ext = f'sip:{safeStripPort(ep_gateway.address)}:5080'
 
-            # update the weight
-            DispatcherEntry = db.query(Dispatcher).filter(
-                (Dispatcher.setid == gwgroupid) & (Dispatcher.destination == "sip:{}".format(sip_addr))
+            # find the current dispatcher entry (load balancing one is always there and has same params as other "feature" sets)
+            ep_dispatcher = db.query(Dispatcher).filter(
+                (Dispatcher.setid == gwgroupid) &
+                (Dispatcher.destination == old_sip_uri)
             ).first()
-            if DispatcherEntry is not None:
-                DispatcherEntry.attrs = Dispatcher.buildAttrs(rweight, signalling, media)
-            else:
-                dispatcher = Dispatcher(setid=gwgroupid, destination=sip_addr, description=name, rweight=rweight,
-                    signalling=signalling, media=media)
-                db.add(dispatcher)
-
-            if int(fusionpbxenabled) > 0:
-                # update the weight for the external load balancer dispatcher set
-                sip_addr_external = safeUriToHost(safeStripPort(host), default_port=5080)
-                DispatcherEntry = db.query(Dispatcher).filter(
-                    (Dispatcher.setid == int(gwgroupid) + 1000) & (Dispatcher.destination == "sip:{}".format(sip_addr_external))
-                ).first()
+            if ep_dispatcher is not None:
                 if rweight is None:
-                    if DispatcherEntry is not None:
-                        db.delete(DispatcherEntry)
+                    rweight = ep_dispatcher.attrsToDict()['rweight']
+                if keepalive is None:
+                    keepalive = 8 & ep_dispatcher.flags
+            else:
+                if rweight is None:
+                    rweight = 0
+                if keepalive is None:
+                    keepalive = 0
+
+            flags = 0
+            if keepalive > 0:
+                flags += Dispatcher.FLAGS['KEEP_ALIVE']
+            if rweight == 0:
+                flags += Dispatcher.FLAGS['DISABLED_DST']
+
+            # update the endpoint in dispatcher
+            sip_uri = f'sip:{sip_addr}'
+            if ep_dispatcher is not None:
+                ep_dispatcher.destination = sip_uri
+                ep_dispatcher.flags = flags
+                ep_dispatcher.attrs = Dispatcher.buildAttrs(rweight, signalling, media)
+                ep_dispatcher.description = name
+            else:
+                ep_dispatcher = Dispatcher(setid=gwgroupid, destination=sip_uri, flags=flags, description=name,
+                    rweight=rweight, signalling=signalling, media=media)
+                db.add(ep_dispatcher)
+
+            # update the fusionpbx dispatcher entries for the endpoint
+            sip_uri_ext = f'sip:{safeStripPort(sip_addr)}:5080'
+            setid_ext = int(gwgroupid) + 1000
+            if fusionpbxenabled:
+                ep_dispatcher_ext = db.query(Dispatcher).filter(
+                    (Dispatcher.setid == setid_ext) &
+                    (Dispatcher.destination == old_sip_uri_ext)
+                ).first()
+                if ep_dispatcher_ext is not None:
+                    ep_dispatcher_ext.destination = sip_uri_ext
+                    ep_dispatcher_ext.flags = flags
+                    ep_dispatcher_ext.attrs = Dispatcher.buildAttrs(rweight, signalling, media)
+                    ep_dispatcher_ext.description = name
                 else:
-                    if DispatcherEntry is not None:
-                        DispatcherEntry.attrs = Dispatcher.buildAttrs(rweight, signalling, media)
-                    else:
-                        # sip_addr_external  = safeUriToHost(hostname, default_port=5080)
-                        # dispatcher = Dispatcher(setid=gwgroupid + 1000, destination=sip_addr_external, attrs="rweight={};".format(rweight),description=name)
-                        # db.add(dispatcher)
-                        pass
+                    ep_dispatcher_ext = Dispatcher(setid=setid_ext, destination=sip_uri_ext, flags=flags, description=name,
+                        rweight=rweight, signalling=signalling, media=media)
+                    db.add(ep_dispatcher_ext)
+            else:
+                # remove the entries if fusionpbx integration is now disabled
+                db.query(Dispatcher).filter(
+                    (Dispatcher.setid == setid_ext) &
+                    (Dispatcher.destination == old_sip_uri_ext)
+                ).delete(synchronize_session=False)
+
+            # update the endpoint in dr_gateways
+            ep_gateway.description = dictToStrFields(endpoint_fields)
+            ep_gateway.address = sip_addr
+            ep_gateway.strip = strip
+            ep_gateway.pri_prefix = prefix
+            ep_gateway.attrs = Gateways.buildAttrs(gwid=gwid, type=current_endpoint['type'], signalling=signalling, media=media)
 
             gwlist.append(gwid)
 
@@ -1418,10 +1488,6 @@ def updateEndpointGroups(gwgroupid=None):
                         raise Exception('Crontab entry could not be deleted')
 
             # Update FusionPBX
-
-            # Convert fusionpbxenabled variable to int
-            if isinstance(fusionpbxenabled, str):
-                fusionpbxenabled = int(fusionpbxenabled)
             # Update
             if fusionpbxenabled == 1:
                 # Update
@@ -1499,7 +1565,8 @@ def addEndpointGroups(data=None, endpointGroupType=None, domain=None):
                     "signalling": "proxy",
                     "media": "proxy",
                     "description": "example",
-                    "rweight": 1
+                    "rweight": 1,
+                    "keepalive": 1
                 }
             ],
             "strip": 0,
@@ -1646,7 +1713,7 @@ def addEndpointGroups(data=None, endpointGroupType=None, domain=None):
             if isinstance(fusionpbxclustersupport, str):
                 fusionpbxclustersupport = int(fusionpbxclustersupport)
 
-            if fusionpbxenabled == 1:
+            if fusionpbxenabled:
                 if fusionpbxclustersupport == 1:
                     domainType = dSIPMultiDomainMapping.FLAGS.TYPE_FUSIONPBX_CLUSTER.value
                 else:
@@ -1677,11 +1744,18 @@ def addEndpointGroups(data=None, endpointGroupType=None, domain=None):
                 raise http_exceptions.BadRequest("Endpoint hostname/address is required")
 
             host = endpoint['host']
-            port = endpoint['port'] if endpoint.get('port', None) is not None else 5060
+            port = int(endpoint['port']) if endpoint.get('port', None) is not None else 5060
             signalling = endpoint['signalling'] if 'signalling' in endpoint else 'proxy'
             media = endpoint['media'] if 'media' in endpoint else 'proxy'
             name = endpoint['description'] if 'description' in endpoint else ''
-            rweight = endpoint['rweight'] if endpoint.get('rweight', None) is not None else 0
+            rweight = int(endpoint['rweight']) if endpoint.get('rweight', None) is not None else 0
+            keepalive = int(endpoint['keepalive']) if endpoint.get('keepalive', None) is not None else 0
+
+            flags = 0
+            if keepalive > 0:
+                flags += Dispatcher.FLAGS['KEEP_ALIVE']
+            if rweight == 0:
+                flags += Dispatcher.FLAGS['DISABLED_DST']
 
             sip_addr = safeUriToHost(host, default_port=port)
             if sip_addr is None:
@@ -1703,15 +1777,17 @@ def addEndpointGroups(data=None, endpointGroupType=None, domain=None):
             # Create dispatcher group with the set id being the gateway group id
             # Don't create a dispatcher set for endpoint groups that was created for MSTeams domains
             if endpointGroupType != "msteams":
-                dispatcher = Dispatcher(setid=gwgroupid, destination=sip_addr, description=name, rweight=rweight,
+                dispatcher = Dispatcher(setid=gwgroupid, destination=sip_addr, flags=flags, description=name, rweight=rweight,
                     signalling=signalling, media=media)
                 db.add(dispatcher)
 
             # Create dispatcher for FusionPBX external interface if FusionPBX feature is enabled
             if fusionpbxenabled:
-                sip_addr_external = safeUriToHost(host, default_port=5080)
+                sip_uri_ext = f'sip:{safeStripPort(sip_addr)}:5080'
+                setid_ext = gwgroupid + 1000
                 # Add 1000 to the gwgroupid so that the setid for the FusionPBX external interface is 1000 apart
-                dispatcher = Dispatcher(setid=gwgroupid + 1000, destination=sip_addr_external, description=name, rweight=rweight)
+                dispatcher = Dispatcher(setid=setid_ext, destination=sip_uri_ext, flags=flags, description=name, rweight=rweight,
+                    signalling=signalling, media=media)
                 db.add(dispatcher)
 
             db.add(Gateway)

--- a/gui/static/js/endpointgroups.js
+++ b/gui/static/js/endpointgroups.js
@@ -47,6 +47,11 @@
     "osrtp_avpf": "OSRTP over RTP/AVPF"
   };
   const MEDIA_OPTIONS_STR = JSON.stringify(MEDIA_OPTIONS);
+  const KEEPALIVE_OPTIONS = {
+    0: "disabled",
+    1: "enabled"
+  };
+  const KEEPALIVE_OPTIONS_STR = JSON.stringify(KEEPALIVE_OPTIONS);
 
   // global variables/constants for this script
   // TODO: find a way to pass these values around gwgroupid instead of using global
@@ -64,7 +69,8 @@
       signalling: jq_row.find('select[name="signalling"]').val(),
       media: jq_row.find('select[name="media"]').val(),
       description: jq_row.find('input[name="description"]').val(),
-      rweight: parseInt(jq_row.find('input[name="rweight"]').val(), 10)
+      rweight: parseInt(jq_row.find('input[name="rweight"]').val(), 10),
+      keepalive: parseInt(jq_row.find('select[name="keepalive"]').val(), 10),
     };
   }
 
@@ -83,6 +89,7 @@
         '<td name="media"></td>' +
         '<td name="description"></td>' +
         '<td name="rweight">1</td>' +
+        '<td name="keepalive"></td>' +
         '</tr>');
     }
     else {
@@ -94,6 +101,7 @@
         '<td name="media">' + MEDIA_OPTIONS[endpoint.media] + '</td>' +
         '<td name="description">' + endpoint.description + '</td>' +
         '<td name="rweight">' + endpoint.rweight.toString() + '</td>' +
+        '<td name="keepalive">' + KEEPALIVE_OPTIONS[endpoint.keepalive] + '</td>' +
         '</tr>');
     }
   }
@@ -110,7 +118,8 @@
           [3, 'signalling', SIGNAL_OPTIONS_STR],
           [4, 'media', MEDIA_OPTIONS_STR],
           [5, 'description'],
-          [6, 'rweight']
+          [6, 'rweight'],
+          [7, 'keepalive', KEEPALIVE_OPTIONS_STR],
         ],
         saveButton: true,
       },
@@ -418,6 +427,10 @@
       success: function(response, textStatus, jqXHR) {
         $('#delete').modal('hide');
         $('#edit').modal('hide');
+
+        // Update Reload buttons
+        reloadKamRequired(true);
+
         gwgroup_table.row(function(idx, data, node) {
           return data.gwgroupid === gwgroupid_int;
         }).remove().draw();

--- a/gui/templates/endpointgroups.html
+++ b/gui/templates/endpointgroups.html
@@ -168,6 +168,13 @@
                 </span>
               </th>
               <th>
+                <span data-toggle="tooltip" data-placement="top" title=""
+                      data-original-title="when enabled, the gateway is sent keepalive messages (at a default interval of 60 seconds).
+                      if disabled, the destination is always attempted when routing">
+                  Keepalive
+                </span>
+              </th>
+              <th>
                 <button class="btn btn-success btn-md" type="button" id="updateEndpointRow">Add Row</button>
               </th>
             </tr>
@@ -424,6 +431,13 @@ systemctl restart fail2ban</code></pre>
                       data-original-title="relative weight (load balancing only) out of sum of endpoint weights in this group.
                       value must be 1-100 or 0 to disable load balancing on this endpoint">
                   Weight
+                </span>
+              </th>
+              <th>
+                <span data-toggle="tooltip" data-placement="top" title=""
+                      data-original-title="when enabled, the gateway is sent keepalive messages (at a default interval of 60 seconds).
+                      if disabled, the destination is always attempted when routing">
+                  Keepalive
                 </span>
               </th>
               <th>

--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -574,10 +574,24 @@ modparam("htable", "db_url", DBURL)
 modparam("dispatcher", "flags", 2)
 modparam("dispatcher", "db_url", DBURL)
 modparam("dispatcher", "table_name", "dispatcher")
-modparam("dispatcher", "ds_probing_mode", 1)			# 1 means to probe each gateway
+# The flags column controls the mode of a destination and keepalives. It is a bitwise value that can be built using the following flags:
+# 1	 (1 <<0):	inactive destination
+# 2  (1 <<1):	temporary trying destination (in the way to become inactive if it does not reply to keepalives
+# 4  (1 <<2):	admin disabled destination
+# 8  (1 <<3):	probing destination (sending keep alives)
+# 16 (1 <<4):	skip DNS A/AAAA resolve at startup, useful when the hostname of the destination address is a NAPTR or SRV record only
+modparam("dispatcher", "flags_col", "flags")
+# Controls what gateways are tested to see if they are reachable:
+# 0:	Only the gateways with state PROBING (flags & 0x08 == 1) are tested. After a gateway is probed, the PROBING state is cleared in this mode (it will probe only one time at startup or after dispatcher reload).
+# 1: 	All gateways are tested. If there is a failure of keepalive to an active gateway, then it is set to TRYING state.
+# 2: 	Only gateways in INACTIVE state with PROBING mode set are tested.
+# 3: 	Any gateway with state PROBING is continually probed without modifying/removing the PROBING state. This allows selected gateways to be probed continually, regardless of state changes.
+modparam("dispatcher", "ds_probing_mode", 3)
 modparam("dispatcher", "ds_ping_latency_stats", 1)		# 1 means to provide latency stats
-modparam("dispatcher", "ds_ping_method", "OPTIONS")
-modparam("dispatcher", "ds_ping_interval", 30)			# How often to ping destinations to check status
+modparam("dispatcher", "ds_ping_method", "OPTIONS")		# The SIP method to use when pinging destinations
+modparam("dispatcher", "ds_ping_interval", 60)			# How often (seconds) to ping destinations to check status
+modparam("dispatcher", "ds_probing_threshold", 1)		# How many failed ping requests before marking the destination as inactive
+modparam("dispatcher", "ds_inactive_threshold", 1)		# How many successful ping requests before marking the destination as active
 modparam("dispatcher", "xavp_dst", "dispatcher_dst")	# Will contain selected destination info
 modparam("dispatcher", "xavp_dst_mode", 0)				# What attributes to set in the xavp
 modparam("dispatcher", "xavp_ctx", "dispatcher_ctx")	# Will contain current dispatcher context info
@@ -1390,9 +1404,9 @@ route[NEXTHOP] {
 				append_hf("P-Asserted-Identity: <sip:$fU@$rd>\r\n");
 			}
 			# TODO: When using the drouting module it may change the $rU by appending a prefix
-			# So, we don't want to reset the $rU 
+			# So, we don't want to reset the $rU
 			#$rU = $var(orig_rU);
-			
+
 			msg_apply_changes();
 			add_contact_alias();
 
@@ -3640,7 +3654,7 @@ onreply_route[WS_REPLY] {
 
 # TODO: FLB_SRC_PBX is not set within in-dialog requests
 route[PBX_TO_ENDPOINT_LOOKUP] {
-	# Lookup the actual location of endpoint if 
+	# Lookup the actual location of endpoint if
 	# coming from a PBX and the request domain is a local ip address
 	if (isbflagset(FLB_SRC_PBX) && is_ip_rfc1918($rd)) {
 		if (lookup("location","sip:$rU@$fd")) {

--- a/kamailio/defaults/dsip_gwgroup2lb.sql
+++ b/kamailio/defaults/dsip_gwgroup2lb.sql
@@ -50,9 +50,6 @@ BEGIN
     -- in case the gwgroupid changed
     SET v_gwgroupid = CAST(COALESCE(NEW.id, OLD.id) AS char);
 
-    -- it is safer to always delete the entry then create new one if setid provided
-    DELETE FROM dsip_gwgroup2lb WHERE gwgroupid = v_gwgroupid;
-
     -- make sure we have a setid
     IF NEW.description REGEXP '(?:lb:|lb_ext:)([0-9]+)' THEN
       SET v_setid = REGEXP_REPLACE(NEW.description, '.*(?:lb:|lb_ext:)([0-9]+).*', '\\1');


### PR DESCRIPTION
  - fix load balanacing failover
  - fix fusionpbx load balancing dispatcher updates
  - fix final dst in load balancing group not disabled when rweight=0
  - add support for enabling/disabling keepalive on endpoints
  - update keepalive to be disabled on enpoints by default
  - update keepalive timeout to 60 seconds
  - fix hanging dispatcher entries in some cases
  - fix edge case where `gwgroup2lb` was not updated correctly