### PR TITLE
Bug/ultradict

### DIFF
--- a/gui/requirements.txt
+++ b/gui/requirements.txt
@@ -1,3 +1,4 @@
+UltraDict
 acme
 ansi2html
 bjoern
@@ -32,5 +33,4 @@ sphinx-rtd-theme
 piccolo_theme
 SQLAlchemy~=2.0
 twilio
-UltraDict
 Werkzeug~=2.0

--- a/resources/terraform/do/main.tf
+++ b/resources/terraform/do/main.tf
@@ -16,7 +16,7 @@ data "digitalocean_ssh_key" "ssh_key" {
 
 
 resource "digitalocean_droplet" "dsiprouter" {
-  name = "${var.dns_demo_hostname}.${var.dns_demo_domain}"
+  name = "${var.dns_hostname}.${var.dns_domain}"
   count = var.number_of_environments
   region = "tor1"
   size = var.image_size	
@@ -44,10 +44,10 @@ resource "digitalocean_droplet" "dsiprouter" {
 }
 
 
-resource "digitalocean_record" "dns_demo_record" {
-  count = var.dns_demo_enabled
-  domain = var.dns_demo_domain
+resource "digitalocean_record" "dns_record" {
+  count = var.number_of_environments
+  domain = var.dns_domain
   type = "A"
-  name = var.dns_demo_hostname
+  name = var.dns_hostname
   value = digitalocean_droplet.dsiprouter.*.ipv4_address[count.index]
 }

--- a/resources/terraform/do/main.tf
+++ b/resources/terraform/do/main.tf
@@ -19,7 +19,7 @@ resource "digitalocean_droplet" "dsiprouter" {
   name = "${var.dns_demo_hostname}.${var.dns_demo_domain}"
   count = var.number_of_environments
   region = "tor1"
-  size = "1gb"
+  size = var.image_size	
   image = var.image
   ssh_keys = [data.digitalocean_ssh_key.ssh_key.fingerprint]
 

--- a/resources/terraform/do/variables.tf
+++ b/resources/terraform/do/variables.tf
@@ -45,6 +45,11 @@ variable "image" {
 	default="debian-12-x64"
 }
 
+variable "image_size" {
+	type=string
+	default="2gb"
+}
+
 variable "additional_commands" {
 	type=string
 	default="echo"

--- a/resources/terraform/do/variables.tf
+++ b/resources/terraform/do/variables.tf
@@ -10,17 +10,12 @@ variable "dsiprouter_prefix" {
 	default=""
 }
 
-variable "dns_demo_domain" {
+variable "dns_domain" {
 	type=string
 	default=""
 }
 
-variable  "dns_demo_enabled" {
-	type=number
-	default=0
-}
-
-variable "dns_demo_hostname" {
+variable "dns_hostname" {
 	type=string
 	default="demo"
 }


### PR DESCRIPTION
- Changed DigitalOcean Terraform scripts to use a VM with 2gb of memory, which seems to be the root cause of the Ultradict package from compiling and installing

- Moved the UltraDict Python package to the top of the list