### PR TITLE
Explictily defined the Kamailio modules that will be installed

### DIFF
--- a/kamailio/debian/12.sh
+++ b/kamailio/debian/12.sh
@@ -100,6 +100,7 @@ DBROOTPORT="${ROOT_DB_PORT}"
 DBROOTUSER="${ROOT_DB_USER}"
 ${ROOTPW_SETTING}
 CHARSET=utf8
+EXTRA_MODULES="imc cpl siptrace domainpolicy carrierroute drouting userblocklist htable purple uac pipelimit mtree sca mohqueue rtpproxy rtpengine secfilter"
 INSTALL_EXTRA_TABLES=yes
 INSTALL_PRESENCE_TABLES=yes
 INSTALL_DBUID_TABLES=yes


### PR DESCRIPTION
This overcomes the bug in the latest version of Kamailio, which has ims_icscf as a default extra module to install, but the corresponding ims_icscf-create.sql file is not part of the Debian package.  Hence causing the Kamailio install portion of dSIPRouter to fail.