### PR TITLE
Fix CentOS 9 Dependencies

### DIFF
--- a/dsiprouter.sh
+++ b/dsiprouter.sh
@@ -461,7 +461,11 @@ function validateOSInfo() {
         ;;
     centos)
         case "$DISTRO_VER" in
-        8|9)
+        9)
+            KAM_VERSION=${KAM_VERSION:-"6.0.2"}
+            RTPENGINE_VER=${RTPENGINE_VER:-"mr11.5.1.11"}
+            ;;
+        8)
             KAM_VERSION=${KAM_VERSION:-"5.8.3"}
             RTPENGINE_VER=${RTPENGINE_VER:-"mr11.5.1.11"}
             ;;

--- a/dsiprouter/centos/9.sh
+++ b/dsiprouter/centos/9.sh
@@ -11,8 +11,8 @@ fi
 function install {
     # Install dependencies for dSIPRouter
     dnf install -y firewalld logrotate rsyslog perl curl python3 python3-devel libpq-devel \
-        libev-devel openldap-devel &&
-    dnf install -y --enablerepo=crb mariadb-devel
+        openldap-devel &&
+    dnf install -y --enablerepo=crb mariadb-devel libev-devel
 
     if (( $? != 0 )); then
         printerr 'Failed installing required packages'


### PR DESCRIPTION
  - libev-devel was moved to crm repo
  - bump kamailio version to 6.0.2 (fixes openssl incompatibility)
