### PR TITLE
Adding fix for Bria Enterprise contact header

### DIFF
--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -3337,7 +3337,10 @@ route[NATMANAGE] {
 	if (is_request() && isflagset(FLT_HAS_TOTAG) && check_route_param("nat=yes")) {
 		setbflag(FLB_NATB);
 	}
-
+	#Fix Refer Contact in Heaader
+    if (is_method("REFER") && $hdr(User-Agent) =~ "Bria") {
+        fix_nated_contact();
+    }
 	if (!isbflagset(FLB_NATB)) {
 		return;
 	}
@@ -4031,7 +4034,10 @@ onreply_route[MANAGE_REPLY] {
                }
 		xlog("L_INFO", "+++ Remove REFER\n");
 	}
-
+	  #Bria: force dialog target to received socket on 200 OK to INVITE
+    if (is_method("INVITE") && t_check_status("200") && $hdr(User-Agent) =~ "Bria") {
+            fix_nated_contact();
+    }
 		# set the final ru for subsequent requests to the contact from the 200
 		if (t_check_status("200")) {
 			if ($ct =~ "<.*>") {


### PR DESCRIPTION
When using Bria Enterprise, the UA sends Contact:Ext@Domain, but uses the domain that it's registering to. When this is proxied by DSIP to a FreePBX system, the FreePBX will try to send the response back to the domain (itself) instead of to the phone. This fixes the contact so it is Contact:Ext@SourceSocket when DSIP proxies to the PBX.