### PR TITLE
Fix TLS transport for registered endpoints and correct record-route 

### DIFF
--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -312,7 +312,7 @@ listen = udp:INTERNAL_IP_ADDR:DMQ_PORT
 enable_tls = true
 tcp_accept_no_cl = true
 tcp_rd_buf_size = 16384
-listen = tls:INTERNAL_IP_ADDR:SIPS_PORT advertise "EXTERNAL_FQDN":SIPS_PORT
+listen = tls:INTERNAL_IP_ADDR:SIPS_PORT advertise "EXTERNAL_IP_ADDR":SIPS_PORT
 #!ifdef WITH_IPV6
 listen = tls:[INTERNAL_IP6_ADDR]:SIPS_PORT advertise "EXTERNAL_FQDN":SIPS_PORT
 #!endif
@@ -1870,6 +1870,12 @@ route[WITHINDLG] {
 		setbflag(FLB_SRC_MSTEAMS_ONHOLD);
 	}
 
+	if (is_method("ACK") || is_method("BYE") || is_method("INFO") || is_method("UPDATE")) {
+            if ($(du{uri.param,transport}) == "tls" || $(ru{uri.param,transport}) == "tls") {
+                xlog("L_INFO", "WITHINDLG forcing TLS socket for in-dialog request\n");
+                force_send_socket(tls:INTERNAL_IP_ADDR:SIPS_PORT);
+				}
+		}
 
 	# sequential request withing a dialog should
 	# take the path determined by record-routing
@@ -2417,8 +2423,12 @@ route[LOCATION] {
 				break;
 			case "udp":
 				$dlg_var(dst_media) = "rtp_avp";
-				$dlg_var(dst_signalling) = "udp";			
+				$dlg_var(dst_signalling) = "sip_udp";			
 				break;		
+  			case "tls":
+                 $dlg_var(dst_media) = "rtp_savp";
+                 $dlg_var(dst_signalling) = "sips_tls";
+                 break;
 			default:
 				$dlg_var(dst_media) = "proxy";
 				$dlg_var(dst_signalling) = "proxy";			
@@ -2811,8 +2821,12 @@ route[SET_CALLDST_INFO] {
 	$dlg_var(dst_gwid) = $var(dst_gwid);
 	$dlg_var(dst_gwtype) = $var(dst_gwtype);
 	$dlg_var(dst_msteams_domain) = $var(dst_msteams_domain);
-	$dlg_var(dst_signalling) = $var(dst_signalling);
-	$dlg_var(dst_media) = $var(dst_media);
+	if (strempty($dlg_var(dst_signalling)) || $dlg_var(dst_signalling) == "proxy") {
+		$dlg_var(dst_signalling) = $var(dst_signalling);
+	}
+	if (strempty($dlg_var(dst_media)) || $dlg_var(dst_media) == "proxy") {
+		$dlg_var(dst_media) = $var(dst_media);
+	}
 	$dlg_var(dst_gwgroupid) = $var(dst_gwgroupid);
 }
 
@@ -2996,6 +3010,11 @@ route[SET_RECORD_ROUTE] {
 		record_route_preset("$dlg_var(src_msteams_domain):SIP_PORT;transport=udp;r2=on", "$dlg_var(src_msteams_domain):SIPS_PORT;transport=tls;r2=on");
 		$dlg_var(sbc_translate) = 1;
 	}
+	else if ($dlg_var(dst_signalling) == "sips_tls") {
+		record_route_preset("EXTERNAL_IP_ADDR:SIPS_PORT;transport=tls;r2=on","INTERNAL_IP_ADDR:SIP_PORT;transport=udp;r2=on");
+		force_send_socket(tls:INTERNAL_IP_ADDR:SIPS_PORT);
+		$dlg_var(sbc_translate) = "0";
+	}
 #!endif
 	# the source of the request will be following the Route / Record-Route headers
 	# so we only need send them back to our internal ip if from within our subnet
@@ -3103,6 +3122,7 @@ route[SET_DST_SIGNALLING] {
 			else {
 				$du = "sips:" + $sel(dst_uri.hostport) + ";transport=tls";
 			}
+			force_send_socket(tls:INTERNAL_IP_ADDR:SIPS_PORT);
 			break;
 		case "sips_sctp":
 			uri_param_rm("transport");


### PR DESCRIPTION
…oute

stops SET_CALLDST_INFO from clobbering tls and breaking dialog routing.

SET_CALLDST_INFO was overwriting dst_signalling and dst_media vars after LOCATION set the transport, causing TLS endpoints to be routed over UDP

Also forces TLS send sockets for sips_tls desinations, fixes alias for ack handling, adds proper record-route handling