### PR TITLE
Carrier Groups - Add Media dropdown for Direct or Proxy

### DIFF
--- a/gui/modules/api/carriergroups/functions.py
+++ b/gui/modules/api/carriergroups/functions.py
@@ -265,6 +265,7 @@ def displayCarriers(gwid=None, gwgroup=None, newgwid=None):
             carriers = [
                 db.query(
                     Gateways.gwid, Gateways.description, Gateways.address, Gateways.strip, Gateways.pri_prefix,
+                    func.SUBSTRING_INDEX(func.SUBSTRING_INDEX(Gateways.attrs, ',', 5), ',', -1).label("media"),
                     Dispatcher.attrs.label("dispatcher_attrs")
                 ).filter(
                     Gateways.gwid == gwid
@@ -288,6 +289,7 @@ def displayCarriers(gwid=None, gwgroup=None, newgwid=None):
                 gwlist = [int(gw) for gw in filter(None, Gatewaygroup.gwlist.split(","))]
                 carriers = db.query(
                     Gateways.gwid, Gateways.description, Gateways.address, Gateways.strip, Gateways.pri_prefix,
+                    func.SUBSTRING_INDEX(func.SUBSTRING_INDEX(Gateways.attrs, ',', 5), ',', -1).label("media"),
                     Dispatcher.attrs.label("dispatcher_attrs")
                 ).filter(
                     Gateways.gwid.in_(gwlist)
@@ -307,6 +309,7 @@ def displayCarriers(gwid=None, gwgroup=None, newgwid=None):
         else:
             carriers = db.query(
                 Gateways.gwid, Gateways.description, Gateways.address, Gateways.strip, Gateways.pri_prefix,
+                func.SUBSTRING_INDEX(func.SUBSTRING_INDEX(Gateways.attrs, ',', 5), ',', -1).label("media"),
                 Dispatcher.attrs.label("dispatcher_attrs")
             ).filter(
                 Gateways.type == settings.FLT_CARRIER
@@ -389,6 +392,7 @@ def addUpdateCarriers(data=None):
         strip = form['strip'] if len(form['strip']) > 0 else '0'
         prefix = form['prefix'] if len(form['prefix']) > 0 else ''
         rweight = int(form['rweight']) if form.get('rweight', '') != '' else 1
+        media = form.get('media', 'proxy') if form.get('media', '') in ('proxy', 'direct') else 'proxy'
 
         if len(hostname) == 0:
             raise http_exceptions.BadRequest("Carrier hostname/address is required")
@@ -405,7 +409,7 @@ def addUpdateCarriers(data=None):
                 db.add(Addr)
                 db.flush()
 
-                Gateway = Gateways(name, sip_addr, strip, prefix, settings.FLT_CARRIER, gwgroup=gwgroup, addr_id=Addr.id)
+                Gateway = Gateways(name, sip_addr, strip, prefix, settings.FLT_CARRIER, gwgroup=gwgroup, addr_id=Addr.id, media=media)
                 db.add(Gateway)
                 db.flush()
 
@@ -417,14 +421,14 @@ def addUpdateCarriers(data=None):
                 Gatewaygroup.gwlist = ','.join(gwlist)
 
                 # Create dispatcher group with the set id being the gateway group id
-                dispatcher = Dispatcher(setid=gwgroup, destination=sip_addr, rweight=rweight, name=name, gwid=gwid)
+                dispatcher = Dispatcher(setid=gwgroup, destination=sip_addr, rweight=rweight, name=name, gwid=gwid, media=media)
                 db.add(dispatcher)
             else:
                 Addr = Address(name, host_addr, 32, settings.FLT_CARRIER)
                 db.add(Addr)
                 db.flush()
 
-                Gateway = Gateways(name, sip_addr, strip, prefix, settings.FLT_CARRIER, addr_id=Addr.id)
+                Gateway = Gateways(name, sip_addr, strip, prefix, settings.FLT_CARRIER, addr_id=Addr.id, media=media)
                 db.add(Gateway)
 
         # Updating
@@ -433,6 +437,8 @@ def addUpdateCarriers(data=None):
             Gateway.address = sip_addr
             Gateway.strip = strip
             Gateway.pri_prefix = prefix
+            gw_attrs = Gateway.attrsToDict()
+            Gateway.attrs = Gateways.buildAttrs(gw_attrs['gwid'], gw_attrs['type'], gw_attrs['msteams_domain'], gw_attrs['signalling'], media)
 
             gw_fields = strFieldsToDict(Gateway.description)
             gw_fields['name'] = name
@@ -443,12 +449,12 @@ def addUpdateCarriers(data=None):
             if db.query(Dispatcher).filter(
                 Dispatcher.description.regexp_match(f'gwid={gwid}(;|$)')
             ).update({
-                "attrs": Dispatcher.buildAttrs(rweight=rweight)
+                "attrs": Dispatcher.buildAttrs(rweight=rweight, media=media)
             }, synchronize_session=False):
                 pass
             # add new dispatcher entry if it did not exist (gwgroup must also exist)
             elif len(gwgroup) > 0:
-                dispatcher = Dispatcher(setid=gwgroup, destination=sip_addr, rweight=rweight, name=name, gwid=gwid)
+                dispatcher = Dispatcher(setid=gwgroup, destination=sip_addr, rweight=rweight, name=name, gwid=gwid, media=media)
                 db.add(dispatcher)
 
             # if address exists update

--- a/gui/static/js/carriergroups.js
+++ b/gui/static/js/carriergroups.js
@@ -421,7 +421,7 @@
       modal_body.find(".strip").val('');
       modal_body.find(".prefix").val('');
       modal_body.find(".rweight").val('');
-
+      modal_body.find(".media").val('proxy');
 
       /* make sure ip_addr not disabled */
       modal_body.find('.ip_addr').prop('disabled', false);
@@ -437,6 +437,7 @@
       var strip = $(c).find('tr:eq(' + row_index + ') td:eq(4)').text();
       var prefix = $(c).find('tr:eq(' + row_index + ') td:eq(5)').text();
       var rweight = $(c).find('tr:eq(' + row_index + ') td:eq(6)').text();
+      var media = $(c).find('tr:eq(' + row_index + ') td.media').text().trim();
 
       /** Clear out the modal */
       var modal_body = $('#edit .modal-body');
@@ -446,6 +447,7 @@
       modal_body.find(".strip").val('');
       modal_body.find(".prefix").val('');
       modal_body.find(".rweight").val('');
+      modal_body.find(".media").val('proxy');
 
       /* update modal fields */
       modal_body.find(".gwid").val(gwid);
@@ -454,6 +456,7 @@
       modal_body.find(".strip").val(strip);
       modal_body.find(".prefix").val(prefix);
       modal_body.find(".rweight").val(rweight);
+      modal_body.find(".media").val(media);
     });
 
     carriers_tbody.on('click', '#open-Delete', function() {
@@ -462,7 +465,7 @@
       var gwid = $(c).find('tr:eq(' + row_index + ') td:eq(1)').text();
       var name = $(c).find('tr:eq(' + row_index + ') td:eq(2)').text();
       var ip_addr = $(c).find('tr:eq(' + row_index + ') td:eq(3)').text();
-      var related_rules = JSON.parse($(c).find('tr:eq(' + row_index + ') td:eq(7)').text());
+      var related_rules = JSON.parse($(c).find('tr:eq(' + row_index + ') td:eq(8)').text());
 
       var modal_body = $('#delete .modal-body');
 

--- a/gui/templates/carriergroups.html
+++ b/gui/templates/carriergroups.html
@@ -107,6 +107,12 @@
         <input class="form-control rweight" type="text" name="rweight"
                placeholder="The amount of traffic allocated to the carrier endpoint (outbound calls)">
       </div>
+      <div class="form-group">
+        <select class="form-control media" name="media">
+          <option value="proxy">Proxy (RTPEngine)</option>
+          <option value="direct">Direct (Media Bypass)</option>
+        </select>
+      </div>
 
       <div class="modal-footer ">
         <button type="submit" id="updateButton" class="btn btn-warning btn-lg" style="width: 100%;"><span
@@ -151,6 +157,12 @@
       <div class="form-group">
         <input class="form-control rweight" type="text" name="rweight"
                placeholder="The amount of traffic allocated to the carrier endpoint (outbound calls)">
+      </div>
+      <div class="form-group">
+        <select class="form-control media" name="media">
+          <option value="proxy">Proxy (RTPEngine)</option>
+          <option value="direct">Direct (Media Bypass)</option>
+        </select>
       </div>
 
       <div class="modal-footer ">

--- a/gui/templates/carriers.html
+++ b/gui/templates/carriers.html
@@ -22,6 +22,7 @@
         Weight
       </span>
     </th>
+    <th data-field="media">Media</th>
     <th colspan="2"></th>
   </tr>
   </thead>
@@ -39,6 +40,7 @@
       <td class='strip'>{{ row.strip }}</td>
       <td class='prefix'>{{ row.pri_prefix }}</td>
       <td class='rweight'>{{ row.dispatcher_attrs|attrFilter('rweight', delims=(';', '=')) }}</td>
+      <td class='media'>{{ row.media or 'proxy' }}</td>
       <td class='related_rules hidden'>{{ related_rules }}</td>
       <td>
         <p data-placement="top" data-toggle="tooltip" title="Edit">


### PR DESCRIPTION
Currently the Carrier Groups hardcodes proxy for the media value, resulting in RTPEngine being required when interacting with a Carrier's endpoint.

This commit adds a dropdown to change the way media is handled:

<img width="577" height="377" alt="image" src="https://github.com/user-attachments/assets/f2b8485c-41bc-4502-9803-4051f7289645" />
