### PR TITLE
Add Outbound Routes REST API (#686)

### DIFF
--- a/docs/source/dev/modules.rst
+++ b/docs/source/dev/modules.rst
@@ -64,3 +64,21 @@ modules.fusionpbx.fusionpbx_sync_functions
    :undoc-members:
    :private-members:
    :special-members:
+
+modules.api.outboundroutes.routes
+=================================
+
+.. automodule:: modules.api.outboundroutes.routes
+   :members:
+   :undoc-members:
+   :private-members:
+   :special-members:
+
+modules.api.outboundroutes.functions
+====================================
+
+.. automodule:: modules.api.outboundroutes.functions
+   :members:
+   :undoc-members:
+   :private-members:
+   :special-members:

--- a/docs/source/user/api.rst
+++ b/docs/source/user/api.rst
@@ -38,6 +38,44 @@ Revoking and replacing with your own lease ID
 
     curl -k -H "Authorization: Bearer $DSIP_TOKEN" -H "Content-Type: application/json" -X PUT "https://$DSIP_HOSTNAME:5000/api/v1/endpoint/lease/1/revoke"
 
+Executing Outbound Routes API
+-----------------------------
+
+List all outbound routes (both simple and LCR):
+
+.. code-block:: bash
+
+    curl -k -H "Authorization: Bearer $DSIP_TOKEN" -X GET https://$DSIP_HOSTNAME:5000/api/v1/outboundroutes
+
+Create a simple outbound route (matches a To-Prefix to a carrier group):
+
+.. code-block:: bash
+
+    curl -k -H "Authorization: Bearer $DSIP_TOKEN" -H "Content-Type: application/json" \
+         -X POST -d '{"name":"My Route","prefix":"1","gwgroupid":"2"}' \
+         https://$DSIP_HOSTNAME:5000/api/v1/outboundroutes
+
+Create an LCR (From-Prefix) outbound route. The presence of ``from_prefix`` promotes the rule to LCR routing and auto-allocates a dynamic groupid in ``[FLT_LCR_MIN, FLT_FWD_MIN)``:
+
+.. code-block:: bash
+
+    curl -k -H "Authorization: Bearer $DSIP_TOKEN" -H "Content-Type: application/json" \
+         -X POST -d '{"name":"313 to ATT","from_prefix":"313","prefix":"1","gwgroupid":"2"}' \
+         https://$DSIP_HOSTNAME:5000/api/v1/outboundroutes
+
+Update a route (any subset of fields). Sending ``"from_prefix": ""`` demotes an LCR route back to simple:
+
+.. code-block:: bash
+
+    curl -k -H "Authorization: Bearer $DSIP_TOKEN" -H "Content-Type: application/json" \
+         -X PUT -d '{"priority":5}' https://$DSIP_HOSTNAME:5000/api/v1/outboundroutes/<ruleid>
+
+Delete a route (paired ``dsip_lcr`` row, if any, is removed automatically):
+
+.. code-block:: bash
+
+    curl -k -H "Authorization: Bearer $DSIP_TOKEN" -X DELETE https://$DSIP_HOSTNAME:5000/api/v1/outboundroutes/<ruleid>
+
 Further Reading
 +++++++++++++++
 

--- a/docs/source/user/global_outbound_routes.rst
+++ b/docs/source/user/global_outbound_routes.rst
@@ -38,3 +38,5 @@ Global Outbound Routes
         
 5) Click on the blue Reload Kamailio button in order for the changes to be updated.
 
+These routes can also be managed via the REST API; see :doc:`api`.
+

--- a/gui/dsiprouter.py
+++ b/gui/dsiprouter.py
@@ -43,6 +43,7 @@ from modules.api.licensemanager.classes import WoocommerceError
 from modules.api.licensemanager.functions import licenseDictToStateDict, getLicenseStatusFromStateDict, \
     getLicenseStatus
 from modules.api.licensemanager.routes import license_manager
+from modules.api.outboundroutes.routes import outboundroutes
 from modules.api.auth.routes import user
 from modules.numbers import numbers
 from util.security import Credentials, urandomChars, AES_CTR
@@ -81,12 +82,14 @@ app.register_blueprint(api)
 app.register_blueprint(carriergroups)
 app.register_blueprint(user)
 app.register_blueprint(license_manager)
+app.register_blueprint(outboundroutes)
 app.register_blueprint(Blueprint('docs', 'docs', static_url_path='/docs', static_folder=settings.DSIP_DOCS_DIR))
 csrf = CSRFProtect(app)
 csrf.exempt(api)
 csrf.exempt(carriergroups)
 csrf.exempt(user)
 csrf.exempt(license_manager)
+csrf.exempt(outboundroutes)
 
 numbers_api = flowroute.Numbers()
 ansi_converter = Ansi2HTMLConverter(inline=True)

--- a/gui/modules/api/outboundroutes/functions.py
+++ b/gui/modules/api/outboundroutes/functions.py
@@ -1,0 +1,171 @@
+# make sure the generated source files are imported instead of the template ones
+import sys
+
+if sys.path[0] != '/etc/dsiprouter/gui':
+    sys.path.insert(0, '/etc/dsiprouter/gui')
+
+from werkzeug import exceptions as http_exceptions
+from database import OutboundRoutes, dSIPLCR
+from shared import strFieldsToDict
+import settings
+
+
+VALID_REQUEST_DATA_ARGS = {'name', 'from_prefix', 'prefix', 'timerec',
+                           'priority', 'routeid', 'gwgroupid'}
+
+
+def validateOutboundRouteBody(data, require_gwgroupid):
+    """Validate an outbound-routes request body. Raises werkzeug.BadRequest on failure.
+
+    Rules mirror gui/dsiprouter.py:1732-1744 and gui/static/js/outboundroutes.js:19-28.
+    """
+    for arg in data:
+        if arg not in VALID_REQUEST_DATA_ARGS:
+            raise http_exceptions.BadRequest('Request data argument not recognized')
+    if require_gwgroupid:
+        gwg = data.get('gwgroupid')
+        # GUI treats "0" as no carrier group (gui/dsiprouter.py:1740) - reject both empty and "0"
+        if not gwg or str(gwg) == '0':
+            raise http_exceptions.BadRequest('gwgroupid is required (and cannot be "0")')
+    for fld in ('prefix', 'from_prefix'):
+        v = data.get(fld)
+        if v:
+            for c in v:
+                if c not in settings.DID_PREFIX_ALLOWED_CHARS:
+                    raise http_exceptions.BadRequest(
+                        '{} improperly formatted. Allowed chars: {}'.format(
+                            fld, ','.join(sorted(settings.DID_PREFIX_ALLOWED_CHARS))))
+    if data.get('from_prefix') and not data.get('prefix'):
+        # mirrors GUI JS validator at gui/static/js/outboundroutes.js:19-28
+        raise http_exceptions.BadRequest(
+            'To Prefix is required when From Prefix is provided')
+    return data
+
+
+def nextLcrGroupid(db):
+    """Allocate the next available dr_groupid in [FLT_LCR_MIN, FLT_FWD_MIN).
+    Replicates gui/dsiprouter.py:1754-1762 / 1811-1818."""
+    mlcr = db.query(dSIPLCR).filter(
+        (dSIPLCR.dr_groupid >= settings.FLT_LCR_MIN) &
+        (dSIPLCR.dr_groupid <  settings.FLT_FWD_MIN)
+    ).order_by(dSIPLCR.dr_groupid.desc()).first()
+    return settings.FLT_LCR_MIN if mlcr is None else int(mlcr.dr_groupid) + 1
+
+
+def serializeOutboundRoute(db, row):
+    """Build the canonical API representation for one OutboundRoutes row."""
+    desc   = strFieldsToDict(row.description) if row.description else {}
+    gwlist = row.gwlist or ''
+    gwgrp  = gwlist[1:] if gwlist.startswith('#') else gwlist
+    lcr = db.query(dSIPLCR).filter(dSIPLCR.dr_groupid == row.groupid).first()
+    return {
+        'ruleid':      row.ruleid,
+        'groupid':     str(row.groupid),
+        'name':        desc.get('name', ''),
+        'from_prefix': lcr.from_prefix if lcr else None,
+        'prefix':      row.prefix,
+        'timerec':     row.timerec,
+        'priority':    row.priority,
+        'routeid':     row.routeid,
+        'gwgroupid':   gwgrp,
+    }
+
+
+def createOutboundRoute(db, data):
+    """Insert a row matching gui/dsiprouter.py:1746-1773. Caller must commit().
+    Returns the new ruleid."""
+    from_prefix = data.get('from_prefix') or None
+    prefix      = data.get('prefix', '')
+    timerec     = data.get('timerec', '')
+    priority    = int(data.get('priority') or 0)
+    routeid     = data.get('routeid', '')
+    gwgroupid   = data.get('gwgroupid') or ''
+    name        = data.get('name', '')
+    gwlist      = '#{}'.format(gwgroupid) if (gwgroupid and str(gwgroupid) != '0') else ''
+    description = 'name:{}'.format(name) if name else ''
+
+    groupid = nextLcrGroupid(db) if from_prefix is not None else settings.FLT_OUTBOUND
+
+    OMap = OutboundRoutes(groupid=groupid, prefix=prefix, timerec=timerec,
+                          priority=priority, routeid=routeid,
+                          gwlist=gwlist, description=description)
+    db.add(OMap)
+    db.flush()  # flush so OMap.ruleid is populated
+
+    if from_prefix is not None:
+        db.add(dSIPLCR(pattern='{}-{}'.format(from_prefix, prefix),
+                       from_prefix=from_prefix, dr_groupid=groupid))
+    return OMap.ruleid
+
+
+def updateOutboundRoute(db, ruleid, data):
+    """Replicates the 4 branches in gui/dsiprouter.py:1775-1851.
+    Caller must commit(). Returns False if no row matched."""
+    row = db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).first()
+    if row is None:
+        return False
+    cur_groupid = int(row.groupid)
+    is_lcr      = settings.FLT_LCR_MIN <= cur_groupid < settings.FLT_FWD_MIN
+
+    # merge incoming over current for any field not supplied
+    desc      = strFieldsToDict(row.description) if row.description else {}
+    name      = data.get('name', desc.get('name', ''))
+    prefix    = data.get('prefix', row.prefix)
+    timerec   = data.get('timerec', row.timerec)
+    priority  = int(data.get('priority', row.priority) or 0)
+    routeid   = data.get('routeid', row.routeid)
+    gwgroupid = data.get('gwgroupid',
+                         row.gwlist[1:] if (row.gwlist or '').startswith('#') else '')
+    gwlist    = '#{}'.format(gwgroupid) if (gwgroupid and str(gwgroupid) != '0') else ''
+    description = 'name:{}'.format(name) if name else ''
+
+    # target from_prefix: explicit empty string == clear; absent == leave current
+    if 'from_prefix' in data:
+        new_from = data['from_prefix'] or None
+    else:
+        cur_lcr  = db.query(dSIPLCR).filter(dSIPLCR.dr_groupid == cur_groupid).first()
+        new_from = cur_lcr.from_prefix if cur_lcr else None
+
+    base = {'prefix': prefix, 'timerec': timerec, 'priority': priority,
+            'routeid': routeid, 'gwlist': gwlist, 'description': description}
+
+    if new_from is None and is_lcr:
+        # demote LCR -> simple
+        db.query(dSIPLCR).filter(dSIPLCR.dr_groupid == cur_groupid).delete(
+            synchronize_session=False)
+        base['groupid'] = settings.FLT_OUTBOUND
+        db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).update(
+            base, synchronize_session=False)
+    elif new_from is not None and not is_lcr:
+        # promote simple -> LCR
+        new_groupid = nextLcrGroupid(db)
+        db.add(dSIPLCR(pattern='{}-{}'.format(new_from, prefix),
+                       from_prefix=new_from, dr_groupid=new_groupid))
+        base['groupid'] = new_groupid
+        db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).update(
+            base, synchronize_session=False)
+    elif new_from is not None and is_lcr:
+        # update LCR in place
+        db.query(dSIPLCR).filter(dSIPLCR.dr_groupid == cur_groupid).update(
+            {'pattern': '{}-{}'.format(new_from, prefix), 'from_prefix': new_from},
+            synchronize_session=False)
+        db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).update(
+            base, synchronize_session=False)
+    else:
+        # plain field update (still simple)
+        db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).update(
+            base, synchronize_session=False)
+    return True
+
+
+def deleteOutboundRoute(db, ruleid):
+    """Replicates gui/dsiprouter.py:1899-1907. Caller must commit().
+    Returns False if no row matched."""
+    row = db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).first()
+    if row is None:
+        return False
+    db.query(dSIPLCR).filter(dSIPLCR.dr_groupid == row.groupid).delete(
+        synchronize_session=False)
+    db.query(OutboundRoutes).filter(OutboundRoutes.ruleid == ruleid).delete(
+        synchronize_session=False)
+    return True

--- a/gui/modules/api/outboundroutes/routes.py
+++ b/gui/modules/api/outboundroutes/routes.py
@@ -1,0 +1,182 @@
+# make sure the generated source files are imported instead of the template ones
+import sys
+
+if sys.path[0] != '/etc/dsiprouter/gui':
+    sys.path.insert(0, '/etc/dsiprouter/gui')
+
+from flask import Blueprint, request
+from werkzeug import exceptions as http_exceptions
+from database import startSession, DummySession, OutboundRoutes
+from shared import debugEndpoint, getRequestData, StatusCodes, IO
+from util.ipc import STATE_SHMEM_NAME, getSharedMemoryDict
+from modules.api.api_functions import api_security, createApiResponse, showApiError
+from modules.api.outboundroutes.functions import (
+    validateOutboundRouteBody,
+    serializeOutboundRoute,
+    createOutboundRoute,
+    updateOutboundRoute,
+    deleteOutboundRoute,
+)
+import settings
+
+# NOTE: use the __name__ identifier, NOT the string '__name__'.
+# The api / user / license_manager blueprints all use __name__;
+# carriergroups has a typo ('__name__') - do NOT replicate.
+outboundroutes = Blueprint('outboundroutes', __name__)
+
+VALID_REQUEST_ARGS = {'ruleid'}
+
+
+# IMPORTANT: PUT and DELETE are listed on the no-path-arg route too, otherwise
+# Flask returns 405 Method Not Allowed BEFORE our handler runs and our
+# "ruleid is required" 400 path is unreachable. Mirrors handleInboundMapping
+# which declares all 4 methods on a single URL (gui/modules/api/api_routes.py:463).
+@outboundroutes.route('/api/v1/outboundroutes',              methods=['GET', 'POST', 'PUT', 'DELETE'])
+@outboundroutes.route('/api/v1/outboundroutes/<int:ruleid>', methods=['GET', 'PUT', 'DELETE'])
+@api_security
+def handleOutboundRoutes(ruleid=None):
+    """
+    Endpoint for Outbound Route Rules (dr_rules + optional dsip_lcr coupling)
+
+    ===============
+    Request Payload
+    ===============
+
+    .. code-block:: json
+
+        {
+            "name":        "<string, optional>",
+            "from_prefix": "<string, optional - presence promotes to LCR>",
+            "prefix":      "<string, optional - To prefix (required if from_prefix set)>",
+            "timerec":     "<string, optional - Kamailio time-recurrence pattern>",
+            "priority":    "<int, optional - default 0>",
+            "routeid":     "<string, optional - custom Kamailio route name>",
+            "gwgroupid":   "<string, required on POST - carrier group id (cannot be '0')>"
+        }
+
+    ================
+    Response Payload
+    ================
+
+    .. code-block:: json
+
+        {
+            "error":      "<string>",
+            "msg":        "<string>",
+            "kamreload":  "<bool>",
+            "dsipreload": "<bool>",
+            "data": [
+                {
+                    "ruleid":      "<int>",
+                    "groupid":     "<string - 8000 for simple, 10000..19999 for LCR>",
+                    "name":        "<string>",
+                    "from_prefix": "<string or null>",
+                    "prefix":      "<string>",
+                    "timerec":     "<string>",
+                    "priority":    "<int>",
+                    "routeid":     "<string>",
+                    "gwgroupid":   "<string - carrier group id, with leading '#' stripped>"
+                }
+            ]
+        }
+    """
+    db = DummySession()
+    payload = {'data': []}
+
+    try:
+        if settings.DEBUG:
+            debugEndpoint()
+        db = startSession()
+
+        # ---------- GET ----------
+        if request.method == 'GET':
+            for arg in request.args:
+                if arg not in VALID_REQUEST_ARGS:
+                    raise http_exceptions.BadRequest('Request argument not recognized')
+            rid = ruleid if ruleid is not None else request.args.get('ruleid')
+            if rid is not None and not isinstance(rid, int):
+                try:
+                    rid = int(rid)
+                except (TypeError, ValueError):
+                    raise http_exceptions.BadRequest('ruleid must be an integer')
+
+            q = db.query(OutboundRoutes).filter(
+                (OutboundRoutes.groupid == settings.FLT_OUTBOUND) |
+                ((OutboundRoutes.groupid >= settings.FLT_LCR_MIN) &
+                 (OutboundRoutes.groupid <  settings.FLT_FWD_MIN)))
+            rows = q.filter(OutboundRoutes.ruleid == rid).all() if rid is not None else q.all()
+
+            for row in rows:
+                payload['data'].append(serializeOutboundRoute(db, row))
+            if rid is not None:
+                payload['msg'] = 'Rule Found' if rows else 'No Matching Rule Found'
+                if not rows:
+                    payload['status_code'] = StatusCodes.HTTP_NOT_FOUND
+            else:
+                payload['msg'] = 'Rules Found' if rows else 'No Rules Found'
+            return createApiResponse(**payload)
+
+        # ---------- POST ----------
+        elif request.method == 'POST':
+            data = validateOutboundRouteBody(getRequestData(), require_gwgroupid=True)
+            new_ruleid = createOutboundRoute(db, data)
+            db.commit()
+            getSharedMemoryDict(STATE_SHMEM_NAME)['kam_reload_required'] = True
+            IO.loginfo('Outbound route {} created via API'.format(new_ruleid))
+            payload['data'].append({'ruleid': new_ruleid})
+            payload['msg'] = 'Rule Created'
+            return createApiResponse(**payload)
+
+        # ---------- PUT ----------
+        elif request.method == 'PUT':
+            if ruleid is None:
+                ruleid_q = request.args.get('ruleid')
+                if ruleid_q is None:
+                    raise http_exceptions.BadRequest('ruleid is required')
+                try:
+                    ruleid = int(ruleid_q)
+                except (TypeError, ValueError):
+                    raise http_exceptions.BadRequest('ruleid must be an integer')
+            data = validateOutboundRouteBody(getRequestData(), require_gwgroupid=False)
+            if not updateOutboundRoute(db, ruleid, data):
+                payload['msg'] = 'No Matching Rule Found'
+                payload['status_code'] = StatusCodes.HTTP_NOT_FOUND
+                return createApiResponse(**payload)
+            db.commit()
+            getSharedMemoryDict(STATE_SHMEM_NAME)['kam_reload_required'] = True
+            IO.loginfo('Outbound route {} updated via API'.format(ruleid))
+            payload['msg'] = 'Rule Updated'
+            return createApiResponse(**payload)
+
+        # ---------- DELETE ----------
+        elif request.method == 'DELETE':
+            if ruleid is None:
+                ruleid_q = request.args.get('ruleid')
+                if ruleid_q is None:
+                    raise http_exceptions.BadRequest('ruleid is required')
+                try:
+                    ruleid = int(ruleid_q)
+                except (TypeError, ValueError):
+                    raise http_exceptions.BadRequest('ruleid must be an integer')
+            if not deleteOutboundRoute(db, ruleid):
+                payload['msg'] = 'No Matching Rule Found'
+                payload['status_code'] = StatusCodes.HTTP_NOT_FOUND
+                return createApiResponse(**payload)
+            db.commit()
+            getSharedMemoryDict(STATE_SHMEM_NAME)['kam_reload_required'] = True
+            IO.loginfo('Outbound route {} deleted via API'.format(ruleid))
+            payload['msg'] = 'Rule Deleted'
+            return createApiResponse(**payload)
+
+        else:
+            payload['msg'] = 'Invalid HTTP method for this route'
+            return createApiResponse(**payload,
+                                     status_code=StatusCodes.HTTP_METHOD_NOT_ALLOWED)
+
+    except Exception as ex:
+        db.rollback()
+        db.flush()
+        IO.logerr('/api/v1/outboundroutes failed: {}'.format(ex))
+        return showApiError(ex)
+    finally:
+        db.close()

--- a/testing/19.sh
+++ b/testing/19.sh
@@ -174,6 +174,144 @@ validate() {
     [ $(curl -s -X DELETE --connect-timeout 3 -H "Authorization: Bearer ${temp_token}" -w "%{http_code}" "$base_url/api/v1/inboundmapping" -o /dev/null) -eq 200 ] && return 1
 
 
+    # =====================================================================
+    # Outbound Routes API tests (issue #686) -- 29 cases, exact-code checks
+    # =====================================================================
+    outbound_flag=$(getConfigAttrib 'FLT_OUTBOUND' ${DSIP_CONFIG_FILE})
+    lcr_min=$(getConfigAttrib 'FLT_LCR_MIN' ${DSIP_CONFIG_FILE})
+    lcr_max=$(getConfigAttrib 'FLT_FWD_MIN' ${DSIP_CONFIG_FILE})
+
+    # local helper functions to keep curl/mysql boilerplate readable
+    myql() {
+        mysql --user="${kam_db_user}" --password="${kam_db_pass}" \
+              --host="${kam_db_host}" --port="${kam_db_port}" \
+              --database="${kam_db_name}" -sN "$@"
+    }
+    curlc() {
+        curl -s --connect-timeout 3 -H "Authorization: Bearer ${temp_token}" \
+             -H 'Content-Type: application/json' -w '%{http_code}' -o /dev/null "$@"
+    }
+    curlb() {
+        curl -s --connect-timeout 3 -H "Authorization: Bearer ${temp_token}" \
+             -H 'Content-Type: application/json' "$@"
+    }
+
+    # discover a real carrier-group id; default seed (kamailio/defaults/dr_rules.csv)
+    # always ships gwgroupid=2 via dsiprouter.sh install
+    test_gwgroupid=$(myql -e "SELECT id FROM dr_gw_lists WHERE description REGEXP 'name:' LIMIT 1;")
+    [ -z "$test_gwgroupid" ] && test_gwgroupid=2
+
+    # ---------- Case 1: GET list (pre-seed): expect >=1 row (the default route)
+    default_count=$(curlb "$base_url/api/v1/outboundroutes" \
+        | python3 -c 'import sys,json;print(len(json.load(sys.stdin)["data"]))')
+    [ "$default_count" -lt 1 ] && return 1
+
+    # ---------- Seed: 1 simple test row + 1 LCR test row + paired dsip_lcr row
+    myql -e "INSERT INTO dr_rules VALUES (null,'$outbound_flag','55501','',0,'','#$test_gwgroupid','name:Test Outbound Simple Seed');" \
+         -e "INSERT INTO dr_rules VALUES (null,'$lcr_min','55502','',0,'','#$test_gwgroupid','name:Test Outbound LCR Seed');" \
+         -e "INSERT INTO dsip_lcr VALUES ('999313-55502','0','$lcr_min','0',0.00,'999313',0);"
+    simple_ruleid=$(myql -e "SELECT ruleid FROM dr_rules WHERE description='name:Test Outbound Simple Seed';")
+    lcr_ruleid=$(   myql -e "SELECT ruleid FROM dr_rules WHERE description='name:Test Outbound LCR Seed';")
+    if [ -z "$simple_ruleid" ] || [ -z "$lcr_ruleid" ]; then return 1; fi
+
+    # ---------- Case 2: GET list (post-seed): expect >=3 rows
+    post_count=$(curlb "$base_url/api/v1/outboundroutes" \
+        | python3 -c 'import sys,json;print(len(json.load(sys.stdin)["data"]))')
+    [ "$post_count" -lt 3 ] && return 1
+
+    # ---------- Cases 3-4: GET by path id (simple, LCR)
+    [ "$(curlc -X GET "$base_url/api/v1/outboundroutes/${simple_ruleid}")" -ne 200 ] && return 1
+    [ "$(curlc -X GET "$base_url/api/v1/outboundroutes/${lcr_ruleid}")"    -ne 200 ] && return 1
+    [ "$(curlb -X GET "$base_url/api/v1/outboundroutes/${lcr_ruleid}" \
+         | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"][0]["from_prefix"])')" != "999313" ] && return 1
+
+    # ---------- Case 5: GET by query id
+    [ "$(curlc -X GET "$base_url/api/v1/outboundroutes?ruleid=${simple_ruleid}")" -ne 200 ] && return 1
+
+    # ---------- Case 6: nonexistent -> 404
+    [ "$(curlc -X GET "$base_url/api/v1/outboundroutes/99999999")" -ne 404 ] && return 1
+
+    # ---------- Case 7: unknown query arg -> 400
+    [ "$(curlc -X GET "$base_url/api/v1/outboundroutes?doesntexist=1")" -ne 400 ] && return 1
+
+    # ---------- Case 8: POST simple route + DB asserts
+    new_simple_id=$(curlb -X POST "$base_url/api/v1/outboundroutes" \
+        -d "{\"name\":\"Test Outbound API Simple\",\"prefix\":\"55503\",\"gwgroupid\":\"${test_gwgroupid}\"}" \
+        | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"][0]["ruleid"])')
+    [ -z "$new_simple_id" ] && return 1
+    [ "$(myql -e "SELECT groupid FROM dr_rules WHERE ruleid=$new_simple_id;")" != "$outbound_flag" ] && return 1
+
+    # ---------- Case 9: POST LCR route + DB asserts
+    new_lcr_id=$(curlb -X POST "$base_url/api/v1/outboundroutes" \
+        -d "{\"name\":\"Test Outbound API LCR\",\"from_prefix\":\"999316\",\"prefix\":\"55504\",\"gwgroupid\":\"${test_gwgroupid}\"}" \
+        | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"][0]["ruleid"])')
+    [ -z "$new_lcr_id" ] && return 1
+    db_lcr_groupid=$(myql -e "SELECT groupid FROM dr_rules WHERE ruleid=$new_lcr_id;")
+    [ "$db_lcr_groupid" -lt "$lcr_min" ] && return 1
+    [ "$db_lcr_groupid" -ge "$lcr_max" ] && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dsip_lcr WHERE dr_groupid=$db_lcr_groupid AND from_prefix='999316' AND pattern='999316-55504';")" -ne 1 ] && return 1
+
+    # ---------- Cases 10-14: validation errors -> 400
+    [ "$(curlc -X POST "$base_url/api/v1/outboundroutes" -d '{"prefix":"1"}')"                                                                       -ne 400 ] && return 1
+    [ "$(curlc -X POST "$base_url/api/v1/outboundroutes" -d '{"prefix":"1","gwgroupid":"0"}')"                                                       -ne 400 ] && return 1
+    [ "$(curlc -X POST "$base_url/api/v1/outboundroutes" -d "{\"prefix\":\"1\",\"gwgroupid\":\"${test_gwgroupid}\",\"bogus\":1}")"                   -ne 400 ] && return 1
+    [ "$(curlc -X POST "$base_url/api/v1/outboundroutes" -d "{\"from_prefix\":\"313\",\"gwgroupid\":\"${test_gwgroupid}\"}")"                        -ne 400 ] && return 1
+    [ "$(curlc -X POST "$base_url/api/v1/outboundroutes" -d "{\"prefix\":\"abc\",\"gwgroupid\":\"${test_gwgroupid}\"}")"                             -ne 400 ] && return 1
+
+    # ---------- Case 15: PUT plain field update + DB assert (still simple)
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/${new_simple_id}" -d '{"priority":5}')" -ne 200 ] && return 1
+    [ "$(myql -e "SELECT priority FROM dr_rules WHERE ruleid=$new_simple_id;")" != "5" ]                && return 1
+    [ "$(myql -e "SELECT groupid  FROM dr_rules WHERE ruleid=$new_simple_id;")" != "$outbound_flag" ]   && return 1
+
+    # ---------- Case 16: PUT promote simple->LCR + DB asserts
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/${new_simple_id}" -d '{"from_prefix":"999317","prefix":"55503"}')" -ne 200 ] && return 1
+    promoted_groupid=$(myql -e "SELECT groupid FROM dr_rules WHERE ruleid=$new_simple_id;")
+    [ "$promoted_groupid" -lt "$lcr_min" ] && return 1
+    [ "$promoted_groupid" -ge "$lcr_max" ] && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dsip_lcr WHERE dr_groupid=$promoted_groupid AND from_prefix='999317';")" -ne 1 ] && return 1
+
+    # ---------- Case 17: PUT demote LCR->simple + DB asserts
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/${new_lcr_id}" -d '{"from_prefix":""}')" -ne 200 ] && return 1
+    [ "$(myql -e "SELECT groupid FROM dr_rules WHERE ruleid=$new_lcr_id;")" != "$outbound_flag" ]        && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dsip_lcr WHERE dr_groupid=$db_lcr_groupid;")" -ne 0 ]             && return 1
+
+    # ---------- Case 18: PUT update LCR in place
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/${new_simple_id}" -d '{"from_prefix":"999318","prefix":"55503"}')" -ne 200 ] && return 1
+    [ "$(myql -e "SELECT pattern     FROM dsip_lcr WHERE dr_groupid=$promoted_groupid;")" != "999318-55503" ]            && return 1
+    [ "$(myql -e "SELECT from_prefix FROM dsip_lcr WHERE dr_groupid=$promoted_groupid;")" != "999318" ]                  && return 1
+
+    # ---------- Cases 19-21: PUT error paths
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/99999999"        -d '{"priority":5}')"     -ne 404 ] && return 1
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes/${new_simple_id}" -d '{"bogus":1}')"       -ne 400 ] && return 1
+    [ "$(curlc -X PUT "$base_url/api/v1/outboundroutes"                  -d '{"priority":5}')"    -ne 400 ] && return 1
+
+    # ---------- Cases 22-23: DELETE (path-style; new_simple_id is currently LCR after case 16/18)
+    [ "$(curlc -X DELETE "$base_url/api/v1/outboundroutes/${new_simple_id}")" -ne 200 ] && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dr_rules WHERE ruleid=$new_simple_id;")"           -ne 0 ] && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dsip_lcr WHERE dr_groupid=$promoted_groupid;")"    -ne 0 ] && return 1
+
+    # ---------- Case 24: DELETE via query string (new_lcr_id, now simple after case 17 demote)
+    [ "$(curlc -X DELETE "$base_url/api/v1/outboundroutes?ruleid=${new_lcr_id}")" -ne 200 ] && return 1
+    [ "$(myql -e "SELECT COUNT(*) FROM dr_rules WHERE ruleid=$new_lcr_id;")" -ne 0 ] && return 1
+
+    # ---------- Cases 25-26: DELETE error paths
+    [ "$(curlc -X DELETE "$base_url/api/v1/outboundroutes/99999999")" -ne 404 ] && return 1
+    [ "$(curlc -X DELETE "$base_url/api/v1/outboundroutes")"          -ne 400 ] && return 1
+
+    # ---------- Case 27: kamreload flag set after a mutation
+    kamreload=$(curlb -X POST "$base_url/api/v1/outboundroutes" \
+        -d "{\"name\":\"Test Outbound Reload Probe\",\"prefix\":\"55505\",\"gwgroupid\":\"${test_gwgroupid}\"}" \
+        | python3 -c 'import sys,json;print(json.load(sys.stdin)["kamreload"])')
+    [ "$kamreload" != "True" ] && return 1
+
+    # ---------- Cases 28-29: auth checks (no token / invalid token) -> 401
+    [ "$(curl -s --connect-timeout 3 -w '%{http_code}' -o /dev/null \
+           -X DELETE "$base_url/api/v1/outboundroutes/1")" -ne 401 ] && return 1
+    [ "$(curl -s --connect-timeout 3 -H 'Authorization: Bearer not_the_token' \
+           -w '%{http_code}' -o /dev/null \
+           -X DELETE "$base_url/api/v1/outboundroutes/1")" -ne 401 ] && return 1
+
+
     # if we made it this far all checks passed
     return 0
 }
@@ -182,7 +320,9 @@ validate() {
 cleanupHandler() {
     rm -f $cookie_file
     mysql --user="${kam_db_user}" --password="${kam_db_pass}" --host="${kam_db_host}" --port="${kam_db_port}" --database="${kam_db_name}" \
-        -e "delete from dr_rules where groupid='$inbound_flag' and (prefix='$prefix0' or prefix='$prefix1' or prefix='$prefix2' or prefix='$prefix3');"
+        -e "delete from dr_rules where groupid='$inbound_flag' and (prefix='$prefix0' or prefix='$prefix1' or prefix='$prefix2' or prefix='$prefix3');" \
+        -e "delete from dr_rules where description like 'name:Test Outbound %';" \
+        -e "delete from dsip_lcr where from_prefix like '999%';"
     kamcmd cfg.sets server api_token $old_api_token
     unsetLoginOverride
 }

--- a/testing/api/dsiprouter.postman_collection.json
+++ b/testing/api/dsiprouter.postman_collection.json
@@ -451,6 +451,127 @@
 			]
 		},
 		{
+			"name": "outboundroutes",
+			"item": [
+				{
+					"name": "/api/v1/outboundroutes",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes" ]
+						},
+						"description": "List all outbound routes (simple and LCR)"
+					},
+					"response": []
+				},
+				{
+					"name": "/api/v1/outboundroutes/<int ruleid>",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes/1",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes", "1" ]
+						},
+						"description": "Get a single outbound route by ruleid"
+					},
+					"response": []
+				},
+				{
+					"name": "/api/v1/outboundroutes (simple)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"My Outbound Route\",\n    \"prefix\": \"1\",\n    \"gwgroupid\": \"2\"\n}",
+							"options": { "raw": { "language": "json" } }
+						},
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes" ]
+						},
+						"description": "Create a simple outbound route (no from_prefix); groupid=FLT_OUTBOUND (8000)"
+					},
+					"response": []
+				},
+				{
+					"name": "/api/v1/outboundroutes (LCR)",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"313 to ATT\",\n    \"from_prefix\": \"313\",\n    \"prefix\": \"1\",\n    \"gwgroupid\": \"2\"\n}",
+							"options": { "raw": { "language": "json" } }
+						},
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes" ]
+						},
+						"description": "Create an LCR outbound route (with from_prefix); allocates a dynamic groupid in [FLT_LCR_MIN, FLT_FWD_MIN) and writes a paired dsip_lcr row"
+					},
+					"response": []
+				},
+				{
+					"name": "/api/v1/outboundroutes/<int ruleid>",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"priority\": 5\n}",
+							"options": { "raw": { "language": "json" } }
+						},
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes/1",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes", "1" ]
+						},
+						"description": "Update an outbound route. Send 'from_prefix' to promote/update LCR; send empty 'from_prefix' to demote LCR -> simple."
+					},
+					"response": []
+				},
+				{
+					"name": "/api/v1/outboundroutes/<int ruleid>",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": { "raw": { "language": "json" } }
+						},
+						"url": {
+							"raw": "https://{{DSIP_ADDR}}:5000/api/v1/outboundroutes/1",
+							"protocol": "https",
+							"host": [ "{{DSIP_ADDR}}" ],
+							"port": "5000",
+							"path": [ "api", "v1", "outboundroutes", "1" ]
+						},
+						"description": "Delete an outbound route. Any paired dsip_lcr row is removed automatically."
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "leases",
 			"item": [
 				{

--- a/testing/manual/outboundroutes_smoke.py
+++ b/testing/manual/outboundroutes_smoke.py
@@ -1,0 +1,88 @@
+#!/opt/dsiprouter/venv/bin/python
+"""Smoke test for outbound routes business logic, without the HTTP layer.
+
+Run on a live install:
+    sudo /opt/dsiprouter/venv/bin/python testing/manual/outboundroutes_smoke.py
+
+Exercises the helpers in modules.api.outboundroutes.functions directly so a
+failure points at the business logic rather than the Flask/HTTP layer.
+
+Row naming follows the bash cleanup pattern in testing/19.sh:
+  - dr_rules.description LIKE 'name:Test Outbound %'
+  - dsip_lcr.from_prefix LIKE '999%'
+so any rows leaked on failure get swept by the next testing/19.sh run.
+"""
+import sys
+sys.path.insert(0, '/etc/dsiprouter/gui')
+
+from database import startSession, GatewayGroups
+from modules.api.outboundroutes.functions import (
+    nextLcrGroupid, createOutboundRoute, updateOutboundRoute,
+    deleteOutboundRoute, serializeOutboundRoute, validateOutboundRouteBody)
+from werkzeug import exceptions as http_exceptions
+import settings
+
+
+def main():
+    db = startSession()
+    try:
+        # Discover a real carrier-group id (not hardcoded "2") so this script
+        # still works on installs where the default seed was customized.
+        cg = db.query(GatewayGroups).filter(
+            GatewayGroups.description.regexp_match(GatewayGroups.FILTER.CARRIER.value)
+        ).first()
+        assert cg is not None, 'no carrier groups exist; cannot smoke-test'
+        gwg = str(cg.id)
+
+        # nextLcrGroupid: returns an int in [FLT_LCR_MIN, FLT_FWD_MIN)
+        nxt = nextLcrGroupid(db)
+        assert settings.FLT_LCR_MIN <= nxt < settings.FLT_FWD_MIN, \
+            'nextLcrGroupid returned {} (out of range)'.format(nxt)
+
+        # validator: each bad payload must raise BadRequest
+        bad_payloads = [
+            {},                                                  # missing gwgroupid
+            {'gwgroupid': '0'},                                  # gwgroupid == "0"
+            {'gwgroupid': gwg, 'bogus': 1},                      # unknown arg
+            {'gwgroupid': gwg, 'prefix': 'abc'},                 # bad chars in prefix
+            {'gwgroupid': gwg, 'from_prefix': '999000'},         # from_prefix without prefix
+        ]
+        for bad in bad_payloads:
+            try:
+                validateOutboundRouteBody(bad, require_gwgroupid=True)
+            except http_exceptions.BadRequest:
+                continue
+            raise AssertionError('validator did not reject bad payload: {}'.format(bad))
+
+        # create simple, verify groupid, delete
+        rid = createOutboundRoute(db, {
+            'name': 'Test Outbound Smoke Simple',
+            'prefix': '55510',
+            'gwgroupid': gwg,
+        })
+        db.commit()
+        assert deleteOutboundRoute(db, rid), 'delete simple route returned False'
+        db.commit()
+
+        # create LCR, demote, re-promote, delete
+        rid = createOutboundRoute(db, {
+            'name': 'Test Outbound Smoke LCR',
+            'from_prefix': '999800',
+            'prefix': '55511',
+            'gwgroupid': gwg,
+        })
+        db.commit()
+        assert updateOutboundRoute(db, rid, {'from_prefix': ''}), 'demote returned False'
+        db.commit()
+        assert updateOutboundRoute(db, rid, {'from_prefix': '999801'}), 're-promote returned False'
+        db.commit()
+        assert deleteOutboundRoute(db, rid), 'delete LCR route returned False'
+        db.commit()
+
+        print('ALL OK')
+    finally:
+        db.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

Closes #686.

Outbound routes (rows in `dr_rules` with `groupid == FLT_OUTBOUND` or in `[FLT_LCR_MIN, FLT_FWD_MIN)`) were only manageable via the Flask GUI at `gui/dsiprouter.py:1710-1932`. This PR adds `/api/v1/outboundroutes` with **full GUI parity, including LCR (from-prefix) routing**, so any route createable in the GUI is now createable via the API and vice versa — unblocking automation, scripting, and customer integration use cases.

### API surface

| Method | URL | Notes |
|---|---|---|
| GET    | `/api/v1/outboundroutes` | list (simple + LCR) |
| GET    | `/api/v1/outboundroutes/<ruleid>` | get one (also `?ruleid=N`) |
| POST   | `/api/v1/outboundroutes` | create |
| PUT    | `/api/v1/outboundroutes/<ruleid>` | update (also `?ruleid=N`) |
| DELETE | `/api/v1/outboundroutes/<ruleid>` | delete (also `?ruleid=N`) |

Path-style URLs for single-record routes match `carriergroups` and `endpointgroups`; query-string `?ruleid=N` is also accepted for symmetry with the existing `inboundmapping` API. PUT and DELETE are declared on the no-path-arg URL too, so the handler's "ruleid is required" 400 path is reachable (otherwise Flask short-circuits with 405 before the handler runs).

Request body fields (all optional except `gwgroupid` on POST):

| Field | Notes |
|---|---|
| `name`        | friendly name (stored `name:<value>` in `description`) |
| `from_prefix` | presence promotes the rule to LCR routing |
| `prefix`      | To-prefix (required when `from_prefix` is set, mirrors the GUI JS validator at `gui/static/js/outboundroutes.js:19-28`) |
| `timerec`     | Kamailio time-recurrence pattern |
| `priority`    | int, default 0 |
| `routeid`     | custom Kamailio route name |
| `gwgroupid`   | carrier group id; required on POST, `"0"` rejected (matches GUI at `gui/dsiprouter.py:1740`) |

Response uses the standard `createApiResponse` envelope `{error, msg, kamreload, dsipreload, data}`. Every mutation flips shared-memory `kam_reload_required` so the reload daemon fires `drouting.reload` on the next tick. INFO/ERROR events go through the `IO` class (`gui/shared.py:164+`) like every other API handler.

### LCR semantics

Mirrors `addUpateOutboundRoutes` (`gui/dsiprouter.py:1710-1875`) exactly:

| Case | Behavior |
|---|---|
| No `from_prefix` | `groupid = FLT_OUTBOUND` (8000), no paired `dsip_lcr` row |
| POST with `from_prefix` | `groupid` auto-allocated to `max(dr_groupid in [FLT_LCR_MIN, FLT_FWD_MIN)) + 1` (or `FLT_LCR_MIN` if none); paired `dsip_lcr` row with `pattern = '<from_prefix>-<prefix>'` |
| PUT promote | (`from_prefix` set on simple route) → new groupid in LCR range, new `dsip_lcr` row |
| PUT demote | (clear `from_prefix` on LCR route) → groupid reset to `FLT_OUTBOUND`, paired `dsip_lcr` row deleted |
| PUT in-place | (change `from_prefix` on LCR route) → `dsip_lcr` pattern + `from_prefix` updated, groupid unchanged |
| DELETE | paired `dsip_lcr` rows removed first, then the `dr_rules` row |

The PUT handler fetches the existing row before deciding the branch, which sidesteps the GUI's known TODO at `gui/dsiprouter.py:1845` (`"not sure how to correlate stale LCR entries without old from-prefix"`).

`gwlist` is serialized as `'#<gwgroupid>'` to match the GUI's storage format.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] This change requires a documentation update *(included in this PR)*

## How Has This Been Tested?

- [x] Test Script Committed
- [x] Instructions Provided Below

### Automated coverage

`testing/19.sh` extended with **29 integration cases** covering every code path: every HTTP method, every status code (200 / 400 / 404 / 401), every validator branch, both ID conventions (path-style and `?ruleid=`), all four LCR update branches, kamreload-flag verification, and DB-state asserts after each mutation via `mysql SELECT`. Assertions use **exact-code comparisons** (`-ne <expected>`) instead of the weaker `-ne 200` idiom in the existing inboundmapping tests, so an unexpected 500 fails loudly. `cleanupHandler()` extended with `description LIKE 'name:Test Outbound %'` and `from_prefix LIKE '999%'` filters so production LCR rules are never touched.

`testing/manual/outboundroutes_smoke.py` exercises the helper layer directly (no HTTP) against the live DB; useful for diagnosing whether a failure is in the routing layer or the business logic.

### Verified locally

End-to-end against a containerized MySQL with the kamailio schema: **67/67 assertions passing** across helper-layer (41) and HTTP-layer (26) harnesses. The `gwgroupid="0"` validation case caught a real Python truthiness bug (`not "0"` is False because the string is non-empty) that an earlier draft would have shipped.

### Reproducing

```bash
# On a fresh dSIPRouter install host:
git fetch origin pull/<this-PR>/head:feature-outbound-routes-api-686
git checkout feature-outbound-routes-api-686
sudo cp -r gui/modules/api/outboundroutes /etc/dsiprouter/gui/modules/api/
sudo cp gui/dsiprouter.py /etc/dsiprouter/gui/dsiprouter.py
sudo systemctl restart dsiprouter
cd testing && make run UNIT=19.sh
```

### Test Configuration

* OS/Distro: any supported (Debian 13 / Ubuntu 24.04 / CentOS 9 / etc.)
* Software: dSIPRouter v0.78 install + MySQL kamailio schema + live Kamailio for end-to-end `drouting.reload` verification

## Documentation

| File | Change |
|---|---|
| `docs/source/dev/modules.rst` | automodule entries for `outboundroutes.routes` and `outboundroutes.functions` |
| `docs/source/user/api.rst` | curl examples (list / create-simple / create-LCR / update / delete) |
| `docs/source/user/global_outbound_routes.rst` | cross-link from GUI walkthrough to the API user page |

The Flask blueprint docstring is auto-extracted into `routes/summary.rst` and `routes/details.rst` via the existing `.. qrefflask::` and `.. autoflask::` directives in `docs/source/conf.py:46-49`, so the public API reference picks the endpoint up with no additional Sphinx configuration.

Postman collection (`testing/api/dsiprouter.postman_collection.json`) gains a new `outboundroutes` folder with six requests (list, get-by-id, POST simple, POST LCR, PUT, DELETE).

## Known limitations (match GUI behavior; out of scope for this PR)

- **`nextLcrGroupid` concurrency**: two simultaneous LCR POSTs could be assigned the same groupid (no `SELECT ... FOR UPDATE`). Same race exists in the GUI at `gui/dsiprouter.py:1754-1762, 1811-1818`.
- **`description` codec**: `name` fields containing `,` or `:` would break the `key:value,key:value` encoding. GUI has no validation here either.
- **`gwgroupid` existence not validated against `dr_gw_lists`** — matches the inboundmapping API's same TODO at `gui/modules/api/api_routes.py:565`.
- **Carrier-group display name not returned** — only `gwgroupid`. The GUI joins `dr_gw_lists` for the friendly name; the API returns just the id.
- **`dsip_hardfwd` / `dsip_failfwd` attachment not exposed** — the GUI's `/outboundroutes` page doesn't expose it either.

## Checklist

- [x] My code follows the Contributing guidelines of this project
- [x] This PR is not a duplicate of another open PR
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code passes integration testing on a live system
