### PR TITLE
Update kamailio.cfg to ring PBX longer than 16 seconds & support Sinch inbound calling

### DIFF
--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -379,7 +379,7 @@ server.pbx_max_local_digits = 5 desc "Maximum digits for local pbx extensions"
 server.pbx_invite_timeout = 5000 desc "The default PBX INVITE timeout"
 
 # PBX INVITE Timeout (msecs) if a SIP 100/180/181/183 message is received
-server.pbx_invite_timeout_aftertry = 16000 desc "PBX INVITE timeout value if a SIP 100 message is received"
+server.pbx_invite_timeout_aftertry = 200000 desc "PBX INVITE timeout value if a SIP 100 message is received"
 
 # DSIPRouter API Server Settings
 server.api_server = "https://127.0.0.1:5000" desc "URL to the DSIPRouter API Server"
@@ -4257,8 +4257,23 @@ route[ENRICH_CARRIER_SIGNALWIRE_OUTBOUND] {
 	}
 }
 
+route[ENRICH_CARRIER_SINCH_INBOUND] {
+	# Strip LNP URI parameters (npdi, rn) from R-URI on inbound calls from Sinch
+	# Transforms: sip:+12532366697;npdi=yes;rn=+12068658505@host:port
+	# Into:       sip:+12532366697@host:port
+	if ($rU =~ ";npdi=") {
+		xlog("L_INFO", "sinch carrier match - stripping LNP params from R-URI user: $rU\n");
+		$rU = $(rU{s.select,0,;});
+		if (!msg_apply_changes()) {
+			xlog("L_ERR", "failed applying changes after stripping LNP params\n");
+		}
+		xlog("L_DBG", "after LNP strip R-URI: $ru\n");
+	}
+}
+
 route[ENRICH_CARRIER_INBOUND] {
 	route(ENRICH_CARRIER_SIGNALWIRE_INBOUND);
+	route(ENRICH_CARRIER_SINCH_INBOUND);
 }
 
 # Carrier Enrichment


### PR DESCRIPTION

FusionPBX does not satisfy incoming calls with pbx_invite_timeout_aftertry getting triggered just after 3 rings, causing the current call to be rejected and the caller will generally reattempt, making a mess of your call log with many missed calls.

Added Sinch parsing on incoming SIP invites to remove values prefixed to the recipient's phone number that prevent Freeswitch from accepting calls.