### PR TITLE
Fixes #759 - Prevents more than one alias parameter from being added …

### DIFF
--- a/kamailio/configs/kamailio.cfg
+++ b/kamailio/configs/kamailio.cfg
@@ -1445,7 +1445,11 @@ route[NEXTHOP] {
 
 			msg_apply_changes();
 			if (!isbflagset(FLB_SRC_MSTEAMS)) {	
-				add_contact_alias();
+			
+				if (!($ct =~ ";alias=")) {
+
+					add_contact_alias();
+				}
 			}
 			route(ENRICH_CARRIER_OUTBOUND);
 


### PR DESCRIPTION
…when the downstream server is another SIP Proxy